### PR TITLE
switch 3 core egeria images to quay.io, increment version, kafka

### DIFF
--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-base
 description: Egeria simple deployment to Kubernetes
 apiVersion: v2
-version: 3.3-prerelease.0
+version: 3.3-prerelease.1
 appVersion: 3.3-SNAPSHOT
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
@@ -17,5 +17,5 @@ maintainers:
     email: nigel.l.jones+git@gmail.com
 dependencies:
   - name: kafka
-    version: 14.2.0
+    version: 14.2.2
     repository: https://charts.bitnami.com/bitnami

--- a/charts/egeria-base/values.yaml
+++ b/charts/egeria-base/values.yaml
@@ -72,7 +72,7 @@ options:
 # Defaults for the images (can be overridden here or individually, see comment below)
 # Note for egeria provided images we use the version specified above
 imageDefaults:
-  registry: docker.io
+  registry: quay.io
   namespace: odpi
   tag: latest
   pullPolicy: IfNotPresent

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v1
-version: 3.3.0-prerelease.3
+version: 3.3.0-prerelease.4
 appVersion: 3.3-SNAPSHOT
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
@@ -19,5 +19,5 @@ maintainers:
     email: nigel.l.jones+git@gmail.com
 dependencies:
   - name: kafka
-    version: 14.2.0
+    version: 14.2.2
     repository: https://charts.bitnami.com/bitnami

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -44,7 +44,7 @@ debug:
 # Defaults for the images (can be overridden here or individually, see comment below)
 # Note for egeria provided images we use the version specified above
 imageDefaults:
-  registry: docker.io
+  registry: quay.io
   namespace: odpi
   tag: latest
   pullPolicy: IfNotPresent
@@ -74,6 +74,7 @@ image:
     name: egeria-ui
     tag: "3.0.1"
   nginx:
+    registry: docker.io
     name: nginx
     namespace:
 


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

* Switches egeria-configure, egeria, jupyter images to use quay.io
* reduces requests to docker hub, to mitigate blocked pulls due to exceeding free account limits
* updates kafka chart version
* increments version

Updates to other images will follow as their build processes are updated