### PR TITLE
Stable egeria ui version

### DIFF
--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v1
-version: 3.3.0-prerelease.4
+version: 3.3.0-prerelease.5
 appVersion: 3.3-SNAPSHOT
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -72,7 +72,7 @@ image:
     tag: "3.3-SNAPSHOT"
   uistatic:
     name: egeria-ui
-    tag: "3.0.1"
+    tag: "3.1.0"
   nginx:
     registry: docker.io
     name: nginx


### PR DESCRIPTION
Egeria UI v3.1.0. This version is tested with open-lineage lab using k8s local deploy.