### PR TITLE
Optionally run configuration for egeria-base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ THIRD_PARTY*.txt
 site/site/
 
 requirements.lock
+
+# MacOS special files
+.DS_Store

--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-base
 description: Egeria simple deployment to Kubernetes
 apiVersion: v2
-version: 3.3.0
+version: 3.3.1
 appVersion: 3.3
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-base/templates/NOTES.txt
+++ b/charts/egeria-base/templates/NOTES.txt
@@ -9,6 +9,7 @@ configurable values
 
 By default a single platform is created using the latest release of Egeria, with a single
 metadata server 'mds1' and a view server 'view1'. The UI organization name is 'org'.
+A job is started to perform this configuration and may take up to 10 minutes to complete.
 
 Please provide any feeback via a github issue at https://github.com/odpi/egeria or 
 join us on slack via https://http://slack.lfai.foundation

--- a/charts/egeria-base/templates/NOTES.txt
+++ b/charts/egeria-base/templates/NOTES.txt
@@ -1,8 +1,14 @@
 ODPi Egeria
 ---
 
-Egeria tutorials has now been deployed to Kubernetes.
+Egeria base environment has now been deployed to Kubernetes.
 It may take a minute or so for everything to start up.
+
+Use 'helm show values egeria/egeria-base' if installed direct from repo to see all
+configurable values
+
+By default a single platform is created using the latest release of Egeria, with a single
+metadata server 'mds1' and a view server 'view1'. The UI organization name is 'org'.
 
 Please provide any feeback via a github issue at https://github.com/odpi/egeria or 
 join us on slack via https://http://slack.lfai.foundation

--- a/charts/egeria-base/templates/config.yaml
+++ b/charts/egeria-base/templates/config.yaml
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the Egeria project.
+
+{{ if .Values.egeria.config }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -10,10 +12,11 @@ metadata:
     helm.sh/chart: {{ include "myapp.chart" . }}
     app.kubernetes.io/name: {{ include "myapp.name" . }}
   annotations:
+    {{ if .Values.options.jobs.config.usehook }}
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "{{ if .Values.options.jobs.config.jobdelete }} hook-succeeded , {{ end }} before-hook-creation"
-
+    {{ end }}
 spec:
   template:
     metadata:
@@ -63,3 +66,4 @@ spec:
             name: {{ .Release.Name }}-scripts-configmap
   # Keep trying quite a few times to aid in debugging
   backoffLimit: {{ .Values.options.jobs.config.backOffLimit }}
+  {{ end }}

--- a/charts/egeria-base/templates/env.yaml
+++ b/charts/egeria-base/templates/env.yaml
@@ -23,6 +23,7 @@ data:
   KAFKA_ENDPOINT: {{ .Release.Name }}-kafka:9092
   EGERIA_SERVER: {{ .Values.egeria.serverName }}
   VIEW_SERVER: {{ .Values.egeria.viewServerName }}
+  EGERIA_PRESENTATIONSERVER_SERVER_{{ .Values.egeria.viewOrg }}: "{\"remoteServerName\":\"{{ .Values.egeria.viewServerName }}\",\"remoteURL\":\"https://{{ .Release.Name }}-platform:9443\"}"
   # Server autostart
   POSTCONFIG_STARTUP_SERVER_LIST: {{ .Values.egeria.serverName }},{{ .Values.egeria.viewServerName }}
   STARTUP_CONFIGMAP: {{ .Release.Name }}-autostart

--- a/charts/egeria-base/templates/presentation.yaml
+++ b/charts/egeria-base/templates/presentation.yaml
@@ -91,9 +91,9 @@ spec:
             periodSeconds: 10
             failureThreshold: 6
           resources: {}
-          env:
-            - name: EGERIA_PRESENTATIONSERVER_SERVER_{{ .Values.egeria.viewOrg }}
-              value: "{\"remoteServerName\":\"{{ .Values.egeria.viewServerName }}\",\"remoteURL\":\"https://{{ .Release.Name }}-platform:9443\"}"
+          envFrom:
+            - configMapRef:
+                name: {{ .Release.Name }}-env
       restartPolicy: Always
 
 status: {}

--- a/charts/egeria-base/values.yaml
+++ b/charts/egeria-base/values.yaml
@@ -23,6 +23,11 @@ egeria:
   storageClass:
   # Default to 8GB
   storageSize: 8Gi
+  # Whether a default configuration is performed or not. Note that the environment for
+  # presentation server is hardcoded based on the viewOrg and viewServerName above EVEN
+  # if the configuration is not actually performed. Note that no autostart setup
+  # will be done either if set to false. Defaults to true
+  config: true
 
 # --- Additional environment variables - inserted directly into configmap. Can use helm template directives
 #extraEnv: |
@@ -65,7 +70,9 @@ options:
       # Default will be true, but during dev set to false
       # This setting will control if the k8s job (and hence pod/logs) are deleted after egeria configuration
       # Set to false to assist in debugging 
-      jobdelete: true    
+      jobdelete: true
+      # If set to true helm install will not complete successfully until configuration is complete
+      usehook: false
 
 # --- Docker image sources ---
 


### PR DESCRIPTION
- Configuration of the default egeria configuration (mds1, view1 etc) via the initialization job is now performed asynchronously after chart installed. This is done by removing the hook specification. The rationale is to make the UX clearer since this is a demo environment. A long 10 minute wait with no output is disconcerting. The original behaviour can be restored with `options.jobs.config.usehook=true`

- Configuration can be disabled by `egeria.config=false` - this allows existing tutorials to use the k8s deployment as a base - since it comes with a single platform and presentation server UI. Note that in this case no scripts are run, though the presentation server configuration is still set to use 'org' as the organization name, and 'mds1' to point to the backend server ie `EGERIA_PRESENTATIONSERVER_SERVER_org:  {"remoteServerName":"view1","remoteURL":"https://base-platform:9443"}`



Fixes #75