### PR TITLE
#76 Set pullPolicy automatically

### DIFF
--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-base
 description: Egeria simple deployment to Kubernetes
 apiVersion: v2
-version: 3.3.1
+version: 3.3.2
 appVersion: 3.3
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-base/templates/config.yaml
+++ b/charts/egeria-base/templates/config.yaml
@@ -32,7 +32,7 @@ spec:
                   {{ if (.Values.image.configure.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.configure.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
                   {{ .Values.image.configure.name }}\
                   :{{ .Values.image.configure.tag | default .Values.egeria.version }}"
-          imagePullPolicy: {{ .Values.image.configure.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          imagePullPolicy: {{ (.Values.image.configure.pullPolicy | default .Values.imageDefaults.pullPolicy) | default (ternary "Always" "IfNotPresent" ( hasSuffix "SNAPSHOT" (.Values.image.configure.tag | default .Values.egeria.version )))  }}
           env:
             - name: SERVICE
               value: {{ .Release.Name }}-platform
@@ -41,7 +41,7 @@ spec:
                   {{ if (.Values.image.configure.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.configure.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
                   {{ .Values.image.configure.name }}\
                   :{{ .Values.image.configure.tag | default .Values.egeria.version }}"
-          imagePullPolicy: {{ .Values.image.configure.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          imagePullPolicy: {{ (.Values.image.configure.pullPolicy | default .Values.imageDefaults.pullPolicy) | default (ternary "Always" "IfNotPresent" ( hasSuffix "SNAPSHOT" (.Values.image.configure.tag | default .Values.egeria.version )))  }}
           env:
             - name: SERVICE
               value: {{ .Release.Name }}-kafka
@@ -51,7 +51,7 @@ spec:
                   {{ if (.Values.image.configure.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.configure.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
                   {{ .Values.image.configure.name }}\
                   :{{ .Values.image.configure.tag | default .Values.egeria.version }}"
-          imagePullPolicy: {{ .Values.image.configure.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          imagePullPolicy: {{ (.Values.image.configure.pullPolicy | default .Values.imageDefaults.pullPolicy) | default (ternary "Always" "IfNotPresent" ( hasSuffix "SNAPSHOT" (.Values.image.configure.tag | default .Values.egeria.version )))  }}
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-env

--- a/charts/egeria-base/templates/platform.yaml
+++ b/charts/egeria-base/templates/platform.yaml
@@ -69,7 +69,7 @@ spec:
                   {{ if (.Values.image.egeria.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.egeria.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
                   {{ .Values.image.egeria.name }}\
                   :{{ .Values.image.egeria.tag | default .Values.egeria.version }}"
-          imagePullPolicy: {{ .Values.image.egeria.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          imagePullPolicy: {{ (.Values.image.egeria.pullPolicy | default .Values.imageDefaults.pullPolicy) | default (ternary "Always" "IfNotPresent" ( hasSuffix "SNAPSHOT" (.Values.image.egeria.tag | default .Values.egeria.version )))  }}
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-env

--- a/charts/egeria-base/templates/presentation.yaml
+++ b/charts/egeria-base/templates/presentation.yaml
@@ -61,7 +61,7 @@ spec:
                   {{ if (.Values.image.presentation.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.presentation.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
                   {{ .Values.image.presentation.name }}\
                   :{{ .Values.image.presentation.tag | default .Values.egeria.version }}"
-          imagePullPolicy: {{ .Values.image.presentation.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          imagePullPolicy: {{ (.Values.image.presentation.pullPolicy | default .Values.imageDefaults.pullPolicy) | default (ternary "Always" "IfNotPresent" ( contains "-rc" (.Values.image.presentation.tag | default .Values.egeria.version )))  }}
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-env

--- a/charts/egeria-base/values.yaml
+++ b/charts/egeria-base/values.yaml
@@ -82,7 +82,8 @@ imageDefaults:
   registry: quay.io
   namespace: odpi
   tag: latest
-  pullPolicy: IfNotPresent
+  # -- pullPolicy is now set automatically to 'Always' for SNAPSHOTs, and 'IfNotPresent' for releases
+  #pullPolicy: IfNotPresent
 
 # The following section defines all of the DOCKER images being used by this chart. Normally they should be left as is,
 # but are exposed here in case the user wishes to extend. By default, each will use the 'imageDefaults' above, but

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v1
-version: 3.3.0
+version: 3.3.1
 appVersion: 3.3
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/templates/egeria-core.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-core.yaml
@@ -69,7 +69,7 @@ spec:
                   {{ if (.Values.image.egeria.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.egeria.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
                   {{ .Values.image.egeria.name }}\
                   :{{ .Values.image.egeria.tag | default .Values.egeria.version }}"
-          imagePullPolicy: {{ .Values.image.egeria.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          imagePullPolicy: {{ (.Values.image.egeria.pullPolicy | default .Values.imageDefaults.pullPolicy) | default (ternary "Always" "IfNotPresent" ( hasSuffix "SNAPSHOT" (.Values.image.egeria.tag | default .Values.egeria.version )))  }}
           envFrom:
             - configMapRef:
                 name: {{ include "myapp.fullname" . }}-configmap

--- a/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
@@ -69,7 +69,7 @@ spec:
                   {{ if (.Values.image.egeria.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.egeria.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
                   {{ .Values.image.egeria.name }}\
                   :{{ .Values.image.egeria.tag | default .Values.egeria.version }}"
-          imagePullPolicy: {{ .Values.image.egeria.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          imagePullPolicy: {{ (.Values.image.egeria.pullPolicy | default .Values.imageDefaults.pullPolicy) | default (ternary "Always" "IfNotPresent" ( hasSuffix "SNAPSHOT" (.Values.image.egeria.tag | default .Values.egeria.version )))  }}
           envFrom:
             - configMapRef:
                 name: {{ include "myapp.fullname" . }}-configmap

--- a/charts/odpi-egeria-lab/templates/egeria-dev.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-dev.yaml
@@ -70,7 +70,7 @@ spec:
                   {{ if (.Values.image.egeria.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.egeria.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
                   {{ .Values.image.egeria.name }}\
                   :{{ .Values.image.egeria.tag | default .Values.egeria.version }}"
-          imagePullPolicy: {{ .Values.image.egeria.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          imagePullPolicy: {{ (.Values.image.egeria.pullPolicy | default .Values.imageDefaults.pullPolicy) | default (ternary "Always" "IfNotPresent" ( hasSuffix "SNAPSHOT" (.Values.image.egeria.tag | default .Values.egeria.version )))  }}
           envFrom:
             - configMapRef:
                 name: {{ include "myapp.fullname" . }}-configmap

--- a/charts/odpi-egeria-lab/templates/egeria-factory.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-factory.yaml
@@ -70,7 +70,7 @@ spec:
                   {{ if (.Values.image.egeria.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.egeria.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
                   {{ .Values.image.egeria.name }}\
                   :{{ .Values.image.egeria.tag | default .Values.egeria.version }}"
-          imagePullPolicy: {{ .Values.image.egeria.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          imagePullPolicy: {{ (.Values.image.egeria.pullPolicy | default .Values.imageDefaults.pullPolicy) | default (ternary "Always" "IfNotPresent" ( hasSuffix "SNAPSHOT" (.Values.image.egeria.tag | default .Values.egeria.version )))  }}
           envFrom:
             - configMapRef:
                 name: {{ include "myapp.fullname" . }}-configmap

--- a/charts/odpi-egeria-lab/templates/egeria-nginx.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-nginx.yaml
@@ -62,7 +62,7 @@ spec:
                   {{ if (.Values.image.nginx.namespace) }}{{ .Values.image.nginx.namespace }}/{{ end }}\
                   {{ .Values.image.nginx.name }}\
                   {{ if (.Values.image.nginx.tag) }}:{{ .Values.image.nginx.tag }}{{ end }}"
-          imagePullPolicy: {{ .Values.image.nginx.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          imagePullPolicy: {{ .Values.image.nginx.pullPolicy | default .Values.imageDefaults.pullPolicy | default "IfNotPresent" }}
           ports:
             - containerPort: 443
           readinessProbe:

--- a/charts/odpi-egeria-lab/templates/egeria-presentation.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-presentation.yaml
@@ -60,7 +60,7 @@ spec:
                   {{ if (.Values.image.presentation.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.presentation.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
                   {{ .Values.image.presentation.name }}\
                   :{{ .Values.image.presentation.tag | default .Values.egeria.version }}"
-          imagePullPolicy: {{ .Values.image.presentation.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          imagePullPolicy: {{ (.Values.image.presentation.pullPolicy | default .Values.imageDefaults.pullPolicy) | default (ternary "Always" "IfNotPresent" ( contains "-rc" (.Values.image.presentation.tag | default .Values.egeria.version )))  }}
           envFrom:
             - configMapRef:
                 name: {{ include "myapp.fullname" . }}-configmap

--- a/charts/odpi-egeria-lab/templates/egeria-ui.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-ui.yaml
@@ -69,7 +69,7 @@ spec:
                   {{ if (.Values.image.egeria.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.egeria.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
                   {{ .Values.image.egeria.name }}\
                   :{{ .Values.image.egeria.tag | default .Values.egeria.version }}"
-          imagePullPolicy: {{ .Values.image.egeria.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          imagePullPolicy: {{ (.Values.image.egeria.pullPolicy | default .Values.imageDefaults.pullPolicy) | default (ternary "Always" "IfNotPresent" ( hasSuffix "SNAPSHOT" (.Values.image.egeria.tag | default .Values.egeria.version )))  }}
           envFrom:
             - configMapRef:
                 name: {{ include "myapp.fullname" . }}-configmap

--- a/charts/odpi-egeria-lab/templates/egeria-uistatic.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-uistatic.yaml
@@ -61,7 +61,7 @@ spec:
                   {{ if (.Values.image.uistatic.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.uistatic.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
                   {{ .Values.image.uistatic.name }}\
                   :{{ .Values.image.uistatic.tag | default .Values.egeria.version }}"
-          imagePullPolicy: {{ .Values.image.uistatic.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          imagePullPolicy: {{ .Values.image.uistatic.pullPolicy | default .Values.imageDefaults.pullPolicy | default "IfNotPresent" }}
           ports:
             - containerPort: 80
           readinessProbe:

--- a/charts/odpi-egeria-lab/templates/jupyter.yaml
+++ b/charts/odpi-egeria-lab/templates/jupyter.yaml
@@ -62,7 +62,7 @@ spec:
                   {{ if (.Values.image.jupyter.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.jupyter.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
                   {{ .Values.image.jupyter.name }}\
                   :{{ .Values.image.jupyter.tag | default .Values.egeria.version }}"
-          imagePullPolicy: {{ .Values.image.jupyter.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          imagePullPolicy: {{ (.Values.image.jupyter.pullPolicy | default .Values.imageDefaults.pullPolicy) | default (ternary "Always" "IfNotPresent" ( hasSuffix "SNAPSHOT" (.Values.image.jupyter.tag | default .Values.egeria.version )))  }}
           envFrom:
             - configMapRef:
                 name: {{ include "myapp.fullname" . }}-configmap

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -47,13 +47,15 @@ imageDefaults:
   registry: quay.io
   namespace: odpi
   tag: latest
-  pullPolicy: IfNotPresent
+  #pullPolicy is now automatically set to Always for snapshots, and IfNotPresent for release
+  #pullPolicy: IfNotPresent
 
 # The following section defines all of the DOCKER images being used by this chart. Normally they should be left as is,
 # but are exposed here in case the user wishes to extend. By default, each will use the 'imageDefaults' above, but
 # these can be individually overridden for each image, if desired, by providing a subkey for 'namespace', 'tag' or
 # 'pullPolicy' with the value to use for the override (if you want to use the public Docker registry, use
 # 'docker.io/library' as the registry override, and set namespace to be your user or organization id).
+# Note that now 'pullPolicy' is automatically set to 'Always' for snapshots, and 'IfNotPresent' for stable releases
 #
 #  To build from egeria source - (example)
 #  mvn clean install -Ddocker -Ddocker.registry=localhost:5000 -Ddocker.repo=odpi


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

For 
 * odpi-egeria-lab
 * egeria-base

The following changes were made:
 
 * Default 'pullPolicy' tag is no longer defined by default (replaced by comment)
 * If a imageDefaults pullPolicy, or image specific pull policy is set, this is respected as before
 * If no pullPolicy is explicitly set (now the default)
   - For egeria images (egeria/configure/jupyer) we use 'Always' if the image tag ends in '-SNAPSHOT', otherwise we use 'IfNotPresent'
   - Similarly for the presentation server, but we look for '-rc' in the version string
   - We default to 'IfNotPresent' for egeria-ui (static component) as there is no identifier in the version distringuishing between a snapshot/release candidate and a final release. This can still be overriden as before
   - For third party images we default to 'IfNotPresent' 
 
 The purpose of this change is to require less changes to values on release and/or less work on users if they want to run snapshots, and avoid confusion where old images are being run. This is based on the premise that prerelease code changes, whilst released code doesn't - and where we can optimize the download/startup time.
 
 Notes: 
 
 1. CTS/PTS charts are not updated
 2. The charts could benefit from some refactoring as they have become pretty verbose, with lots of commonality. This was not done as part of this change.