### PR TITLE
#101 initial version of egeria lab using strimzi as the kafka impleme…

### DIFF
--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v1
-version: 3.4.0
+version: 3.4.1-prerelease.1
 appVersion: 3.4
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
@@ -18,6 +18,6 @@ maintainers:
   - name: Nigel Jones
     email: nigel.l.jones+git@gmail.com
 dependencies:
-  - name: kafka
-    version: 14.4.1
-    repository: https://charts.bitnami.com/bitnami
+  - name: strimzi-kafka-operator
+    version: 0.26.0
+    repository: https://strimzi.io/charts/

--- a/charts/odpi-egeria-lab/templates/jupyter.yaml
+++ b/charts/odpi-egeria-lab/templates/jupyter.yaml
@@ -83,7 +83,7 @@ spec:
             - name: factoryPlatformURL
               value: "https://{{ .Release.Name }}-factory:9443"
             - name: eventBusURLroot
-              value: "{{ .Release.Name }}-kafka:9092"
+              value: "{{ .Release.Name }}-strimzi-kafka-bootstrap:9092"
             - name: uiExternalURL
               value: "{{ .Release.Name }}-nginx:443"
             - name: repositoryType

--- a/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
+++ b/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+  # Copyright Contributors to the Egeria project.
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: {{ include "myapp.fullname" . }}
+spec:
+  kafka:
+    version: 3.0.0
+    replicas: 1
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      log.message.format.version: "3.0"
+      inter.broker.protocol.version: "3.0"
+    storage:
+      type: jbod
+      volumes:
+        - id: 0
+          type: persistent-claim
+          size: 5Gi
+          deleteClaim: true
+    template:
+      pod:
+        securityContext:
+          runAsUser: 1001
+          fsGroup: 0
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: 1Gi
+      deleteClaim: true
+    template:
+      pod:
+        securityContext:
+          runAsUser: 1001
+          fsGroup: 0
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}

--- a/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
+++ b/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
@@ -4,7 +4,7 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
-  name: {{ include "myapp.fullname" . }}
+  name: {{ .Release.Name }}-strimzi
 spec:
   kafka:
     version: 3.0.0

--- a/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
+++ b/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
@@ -20,6 +20,13 @@ spec:
       transaction.state.log.min.isr: 1
       log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
+      auto.create.topics.enable: "true"
+    readinessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    livenessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
     storage:
       type: jbod
       volumes:
@@ -44,5 +51,7 @@ spec:
           runAsUser: 1001
           fsGroup: 0
   entityOperator:
-    topicOperator: {}
-    userOperator: {}
+    topicOperator:
+      reconciliationIntervalSeconds: 20
+    userOperator: 
+      reconciliationIntervalSeconds: 20

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -95,21 +95,3 @@ image:
 
 persistence:
   enabled: false
-
-# When using the k8s-internal Kafka (from Bitnami), enable auto-topic creation and minimize the footprint
-# See https://github.com/bitnami/charts/tree/master/bitnami/kafka for more info
-kafka:
-    #volumePermissions:
-    #enabled: true
-    securityContext:
-        enabled: false
-    zookeeper:
-        persistence: 
-            enabled: false
-    persistence: 
-        enabled: false
-    logpersistence: 
-        enabled: false
-    #can be enabled if external kafka access is required
-    #service:
-        #nodeport: 30092


### PR DESCRIPTION
Initial version of odpi-egeria-lab helm chart that uses strimzi
 - removed dependency of bitnami helm chart
 - added dependency on strimzi helm chart
 - added CR for a simple cluster (inc. security context to address permission issues)
 - Increments to new prerelease version
 - other charts untouched for first version
 - lab notebooks run ok - cohorts communicating ok
 - strimzi CRs can be interrogated to pick up topic names from egeria etc
 
 Known issues (may need addressing before merge):
 
 - entity operator eviction
```
lab-strimzi-odpi-egeria-lab-entity-operator-655c664bb5-4pnfj   0/3     Evicted   0          10m
lab-strimzi-odpi-egeria-lab-entity-operator-655c664bb5-5kflw   0/3     Evicted   0          8m23s
lab-strimzi-odpi-egeria-lab-entity-operator-655c664bb5-krj7p   3/3     Running   1          7m37s
```
```
Status:         Failed
Reason:         Evicted
Message:        Usage of EmptyDir volume "strimzi-uo-tmp" exceeds the limit "1Mi".
```
Cause: See https://github.com/strimzi/strimzi-kafka-operator/issues/5579 - bug in 0.26.0

*UPDATE* Now fixed -- this error path occurs when the kafka cluster config is wrong (and can't be scheduled).. with a valid configuration for coco pharma, this issues does not occur...

The fix is in main, and will be in the next strimzi release .

Points for review
 - This version does not support ARM, but future versions should do - requiring little more than a version increment of the dependent chart
 - strimzi is fully open source (bitnami is not - at least in terms of the tooling/build process for the charts & images)
 - Initialization takes longer
 - more pods, so more clutter (for tutorials...)
 - other charts can get updated if this looks a good approach
 - have not made the kafka implementation optional - the chart is opinionated ....
 - can revert before next release/agreement to move from prerelease, but publishing chart enables broader testing with community, essential for upcoming Dojo
 - persistent storage is used. However the settings are such that the pvc (storage claim) is deleted when the helm chart is deleted. This avoids issues where a later install may pick up prior cohort messages & confuse the environment. this is a particular approach for lab tutorials
 
Community testing (after merge/chart build)
  * `helm repo add egeria https://odpi.github.io/egeria-charts`
  * `helm repo search egeria --devel`
  * `helm install egeria/odpi-egeria-lab --devel`

Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>