### PR TITLE
Decoupling of egeria-base chart and improvements on configuration

### DIFF
--- a/charts/egeria-platform/Chart.yaml
+++ b/charts/egeria-platform/Chart.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
 apiVersion: v2
 name: egeria-platform
 description: Egeria Platform

--- a/charts/egeria-platform/Chart.yaml
+++ b/charts/egeria-platform/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: egeria-platform
+description: Egeria Platform for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 3.5.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "3.5"
+
+icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
+sources:
+  - https://github.com/odpi/egeria
+home: https://github.com/odpi/egeria
+dependencies: []

--- a/charts/egeria-platform/Chart.yaml
+++ b/charts/egeria-platform/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: egeria-platform
-description: Egeria Platform for Kubernetes
+description: Egeria Platform
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/charts/egeria-platform/Chart.yaml
+++ b/charts/egeria-platform/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.5.0
+version: 3.5.0-prerelease.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.5"
+appVersion: "3.5-SNAPSHOT"
 
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 sources:

--- a/charts/egeria-platform/Chart.yaml
+++ b/charts/egeria-platform/Chart.yaml
@@ -22,9 +22,12 @@ version: 3.5.0-prerelease.0
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "3.5-SNAPSHOT"
-
+keywords:
+  - odpi, egeria, base, simple
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 sources:
-  - https://github.com/odpi/egeria
-home: https://github.com/odpi/egeria
+  - https://github.com/odpi/egeria-charts
+home: https://github.com/odpi/egeria-charts
+maintainers:
+  - name: Max Simon
 dependencies: []

--- a/charts/egeria-platform/README.md
+++ b/charts/egeria-platform/README.md
@@ -1,3 +1,6 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- # Copyright Contributors to the Egeria project. -->
+
 # egeria-platform
 
 This chart is based on `egeria-base` chart in https://github.com/odpi/egeria-charts, but it handles configuration differently and allows for multiple server platforms.

--- a/charts/egeria-platform/README.md
+++ b/charts/egeria-platform/README.md
@@ -1,0 +1,58 @@
+# egeria-platform
+
+This repository is based on https://github.com/odpi/egeria-charts, but it handles configuration differently and allows for multiple server platforms.
+
+
+## Prerequisite: Install Kafka
+
+Kafka is not a dependency of this Helm Chart and must be installed beforehand.
+
+```
+helm repo add bitnami
+helm install egeria-kafka bitnami/kafka
+```
+
+This will deploy Bitnami Kafka (https://charts.bitnami.com/bitnami).
+
+*In the following steps it is assumed that the corresponding service is named `egeria-kafka` on port 9092. If you deploy with other settings you need to adjust the following steps.*
+
+If Kafka is deployed to OpenShift, both service accounts `default` and `egeria-kafka` need to have the `system:openshift:scc:anyuid` cluster role.
+
+## Deploy Egeria Servers
+
+Egeria Servers are deployed on an *Egeria Server Platform*. After starting the platform, servers can be configured by issuing REST calls to the platform. If the Egeria server finds configuration documents in the file system, it automatically starts up the servers. **Starting a server using REST call when the same server was already configured is discouraged.**
+
+The [main configuration script](scripts/run.sh) will check which server configurations are already present and which need to be configured.
+
+The configuration script for a server needs to be placed in `/home/jboss/scripts/config-<server-name>.sh` in the container image. The following environment variables can be used in the configuration scripts:
+- `EGERIA_ENDPOINT`: the URL for the server platform
+- `EGERIA_LOCAL_ENDPOINT`: the localhost URL for the server platform, use this as the target for curl requests during startup
+- `EGERIA_USER`: a user that can make admin requests
+- `EGERIA_COHORT`: cohort of the server platform
+- `EGERIA_KAFKA_ENDPOINT`: URL of Kafka installation (see above)
+- `EGERIA_VIEW_ORG`: organisation for view
+- `EGERIA_OMAG_SERVER_NAME`: name of the OMAG Server (usually mds1)
+- `EGERIA_OMAG_SERVER_URL`: URL of the OMAG Server (its platform url)
+
+### Deploy an OMAG Server and a View Server
+
+Use the following settings in `egeria-platform` helm chart:
+- set `egeria.serverList` to `mds1,view1`
+- set `egeria.omagServer.name` to `mds1` and `egeria.omagServer.platformUrl` to `` (this will resolve to the platform URL of the deployment)
+- adjust `egeria.kafkaEndpoint` to use the correct Kafka address (see above)
+- make sure that the correct image is used (this must contain `config-mds1.sh` and `config-view1.sh`)
+
+Run
+```
+helm install egeria-platform ./egeria-platform
+```
+to create the Egeria platform with `mds1` and `view1` deployed.
+
+### Deploy additional servers
+
+The Helm chart can be used to deploy additional Server Platforms with different server types running on this platform. To do so, the following settings need to be adjusted in `values.yaml`:
+- set `egeria.serverList` to the desired server types
+- set `egeria.omagServer.name` to `mds1` and `egeria.omagServer.platformUrl` to `https://egeria-platform:9443` (the URL depends on the chart name used to deploy the OMAG server)
+- adjust `egeria.kafkaEndpoint` to use the correct Kafka address (see above)
+- provide additional environment variables that are required by configuration script via `extraEnv`
+- provide additional secrets with environment variables by referencing a Kubernetes secret in `egeria-pull-secrets`. The secret will used as environment variable in the pod.

--- a/charts/egeria-platform/README.md
+++ b/charts/egeria-platform/README.md
@@ -1,6 +1,6 @@
 # egeria-platform
 
-This repository is based on https://github.com/odpi/egeria-charts, but it handles configuration differently and allows for multiple server platforms.
+This chart is based on `egeria-base` chart in https://github.com/odpi/egeria-charts, but it handles configuration differently and allows for multiple server platforms.
 
 
 ## Prerequisite: Install Kafka
@@ -38,7 +38,7 @@ The configuration script for a server needs to be placed in `/home/jboss/scripts
 
 Use the following settings in `egeria-platform` helm chart:
 - set `egeria.serverList` to `mds1,view1`
-- set `egeria.omagServer.name` to `mds1` and `egeria.omagServer.platformUrl` to `` (this will resolve to the platform URL of the deployment)
+- set `egeria.omagServer.name` to `mds1` and `egeria.omagServer.platformUrl` to `` (an empty string will be replaced with the platform URL of the deployment)
 - adjust `egeria.kafkaEndpoint` to use the correct Kafka address (see above)
 - make sure that the correct image is used (this must contain `config-mds1.sh` and `config-view1.sh`)
 

--- a/charts/egeria-platform/scripts/config-daemon.sh
+++ b/charts/egeria-platform/scripts/config-daemon.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# wait until Egeria API is ready
+status_code=$(curl -s -o /dev/null -w "%{http_code}" -k -X GET ${EGERIA_LOCAL_ENDPOINT}/open-metadata/platform-services/users/${EGERIA_USER}/server-platform/origin)
+until [ $status_code -eq 200 ]; do
+    echo "Status code: ${status_code}"
+    sleep 2;
+    status_code=$(curl -s -o /dev/null -w "%{http_code}" -k -X GET ${EGERIA_LOCAL_ENDPOINT}/open-metadata/platform-services/users/${EGERIA_USER}/server-platform/origin)
+done;
+echo "Egeria Tomcat Server is up and running"
+
+# log environment variables
+echo '-- Environment variables --'
+env
+echo '-- End of Environment variables --'
+
+# execute configuration scripts
+CONFIG_SERVER_LIST_ARR=($(echo $CONFIG_SERVER_LIST | tr "," "\n"))
+for SERVER in "${CONFIG_SERVER_LIST_ARR[@]}";
+do
+    echo '-- Start configuring ${SERVER} --'
+    /home/jboss/scripts/config-${SERVER}.sh
+    echo '-- End configuring ${SERVER}'
+done
+
+# create file to let startupProbe succeed
+echo "Done" > /tmp/done.txt

--- a/charts/egeria-platform/scripts/config-daemon.sh
+++ b/charts/egeria-platform/scripts/config-daemon.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
+
 # wait until Egeria API is ready
 status_code=$(curl -s -o /dev/null -w "%{http_code}" -k -X GET ${EGERIA_LOCAL_ENDPOINT}/open-metadata/platform-services/users/${EGERIA_USER}/server-platform/origin)
 until [ $status_code -eq 200 ]; do

--- a/charts/egeria-platform/scripts/config-mds1.sh
+++ b/charts/egeria-platform/scripts/config-mds1.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
+
 echo -e '\n-- Configuring platform with requires servers'
 
 # Set the URL root

--- a/charts/egeria-platform/scripts/config-mds1.sh
+++ b/charts/egeria-platform/scripts/config-mds1.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 echo -e '\n-- Configuring platform with requires servers'
 
 # Set the URL root

--- a/charts/egeria-platform/scripts/config-mds1.sh
+++ b/charts/egeria-platform/scripts/config-mds1.sh
@@ -1,0 +1,37 @@
+echo -e '\n-- Configuring platform with requires servers'
+
+# Set the URL root
+echo -e '\n\n > Setting server URL root:\n'
+curl -f -k --verbose --basic admin:admin -X POST \
+  "${EGERIA_LOCAL_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_OMAG_SERVER_NAME}/server-url-root?url=${EGERIA_ENDPOINT}"
+
+# Setup the event bus
+echo -e '\n\n > Setting up event bus:\n'
+curl -f -k --verbose --basic admin:admin \
+  --header "Content-Type: application/json" \
+  "${EGERIA_LOCAL_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_OMAG_SERVER_NAME}/event-bus" \
+  --data '{"producer": {"bootstrap.servers": "'"${EGERIA_KAFKA_ENDPOINT}"'"}, "consumer": {"bootstrap.servers": "'"${EGERIA_KAFKA_ENDPOINT}"'"} }'
+
+# Enable all the access services (we will adjust this later)
+echo -e '\n\n > Enabling all access servces:\n'
+curl -f -k --verbose --basic admin:admin -X POST \
+  "${EGERIA_LOCAL_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_OMAG_SERVER_NAME}/access-services?serviceMode=ENABLED"
+
+# Use a local graph repo
+echo -e '\n\n > Use local graph repo:\n'
+curl -f -k --verbose --basic admin:admin -X POST \
+  "${EGERIA_LOCAL_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_OMAG_SERVER_NAME}/local-repository/mode/local-graph-repository"
+
+# Configure the cohort membership
+echo -e '\n\n > configuring cohort membership:\n'
+curl -f -k --verbose --basic admin:admin -X POST \
+  "${EGERIA_LOCAL_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_OMAG_SERVER_NAME}/cohorts/${EGERIA_COHORT}"
+
+# Start up the server, might take some time
+echo -e '\n\n > Starting the server:\n'
+curl -f -k --verbose --basic admin:admin -X POST --max-time 900 \
+  "${EGERIA_LOCAL_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_OMAG_SERVER_NAME}/instance"
+
+
+
+

--- a/charts/egeria-platform/scripts/config-view1.sh
+++ b/charts/egeria-platform/scripts/config-view1.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 export EGERIA_VIEW_SERVER=view1
 
 # Set the URL root

--- a/charts/egeria-platform/scripts/config-view1.sh
+++ b/charts/egeria-platform/scripts/config-view1.sh
@@ -1,0 +1,146 @@
+export EGERIA_VIEW_SERVER=view1
+
+# Set the URL root
+echo -e '\n\n > Setting view server URL root:\n'
+curl -f -k --verbose --basic admin:admin -X POST \
+  "${EGERIA_LOCAL_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_VIEW_SERVER}/server-url-root?url=${EGERIA_ENDPOINT}"
+
+# Setup the event bus
+echo -e '\n\n > Setting up event bus:\n'
+curl -f -k --verbose --basic admin:admin \
+  --header "Content-Type: application/json" \
+  "${EGERIA_LOCAL_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_VIEW_SERVER}/event-bus" \
+  --data '{"producer": {"bootstrap.servers": "'"${EGERIA_KAFKA_ENDPOINT}"'"}, "consumer": {"bootstrap.servers": "'"${EGERIA_KAFKA_ENDPOINT}"'"} }'
+
+# Set as view server
+echo -e '\n\n > Set as view server:\n'
+curl -f -k --verbose --basic admin:admin -X POST \
+  "${EGERIA_LOCAL_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_VIEW_SERVER}/server-type?typeName=View%20Server"
+
+# Configure the view server cohort membership
+echo -e '\n\n > configuring cohort membership:\n'
+curl -f -k --verbose --basic admin:admin -X POST \
+  "${EGERIA_LOCAL_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_VIEW_SERVER}/cohorts/${EGERIA_COHORT}"
+
+# Configure the view services
+echo -e '\n\n > Setting up Glossary Author:\n'
+curl -f -k --verbose --basic admin:admin \
+   --header "Content-Type: application/json" \
+   "${EGERIA_LOCAL_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_VIEW_SERVER}/view-services/glossary-author" \
+   --data @- <<EOF
+{
+  "class": "ViewServiceConfig",
+  "omagserverPlatformRootURL": "${EGERIA_OMAG_SERVER_URL}",
+  "omagserverName" : "${EGERIA_OMAG_SERVER_NAME}"
+}
+EOF
+
+echo -e '\n\n > Setting up TEX:\n'
+curl -f -k --verbose --basic admin:admin \
+  --header "Content-Type: application/json" \
+  "${EGERIA_LOCAL_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_VIEW_SERVER}/view-services/tex" \
+  --data @- <<EOF
+{
+  "class":"IntegrationViewServiceConfig",
+  "viewServiceAdminClass":"org.odpi.openmetadata.viewservices.tex.admin.TexViewAdmin",
+  "viewServiceFullName":"Type Explorer",
+  "viewServiceOperationalStatus":"ENABLED",
+  "omagserverPlatformRootURL": "UNUSED",
+  "omagserverName" : "UNUSED",
+  "resourceEndpoints" : [
+    {
+      "class"              : "ResourceEndpointConfig",
+      "resourceCategory"   : "Platform",
+      "description"        : "Platform",
+      "platformName"       : "platform",
+      "platformRootURL"    : "${EGERIA_ENDPOINT}"
+    },
+    {
+      "class"              : "ResourceEndpointConfig",
+      "resourceCategory"   : "Server",
+      "serverInstanceName" : "${EGERIA_OMAG_SERVER_NAME}",
+      "description"        : "Server",
+      "platformName"       : "platform",
+      "serverName"         : "${EGERIA_OMAG_SERVER_NAME}"
+    }
+  ]
+}
+EOF
+
+echo -e '\n\n > Setting up REX:\n'
+curl -f -k --verbose --basic admin:admin \
+  --header "Content-Type: application/json" \
+  "${EGERIA_LOCAL_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_VIEW_SERVER}/view-services/rex" \
+  --data @- <<EOF
+{
+  "class":"IntegrationViewServiceConfig",
+  "viewServiceAdminClass":"org.odpi.openmetadata.viewservices.rex.admin.RexViewAdmin",
+  "viewServiceFullName":"Repository Explorer",
+  "viewServiceOperationalStatus":"ENABLED",
+  "omagserverPlatformRootURL": "UNUSED",
+  "omagserverName" : "UNUSED",
+  "resourceEndpoints" : [
+    {
+        "class"              : "ResourceEndpointConfig",
+        "resourceCategory"   : "Platform",
+        "description"        : "Platform",
+        "platformName"       : "platform",
+        "platformRootURL"    : "${EGERIA_ENDPOINT}"
+    },
+                  {
+        "class"              : "ResourceEndpointConfig",
+        "resourceCategory"   : "Server",
+        "serverInstanceName" : "${EGERIA_OMAG_SERVER_NAME}",
+        "description"        : "Server",
+        "platformName"       : "platform",
+        "serverName"         : "${EGERIA_OMAG_SERVER_NAME}"
+    }
+  ]
+}
+EOF
+
+echo -e '\n\n > Setting up DINO:\n'
+curl -f -k --verbose --basic admin:admin \
+  --header "Content-Type: application/json" \
+  "${EGERIA_LOCAL_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_VIEW_SERVER}/view-services/dino" \
+  --data @- <<EOF
+{
+  "class":"IntegrationViewServiceConfig",
+  "viewServiceAdminClass":"org.odpi.openmetadata.viewservices.dino.admin.DinoViewAdmin",
+  "viewServiceFullName":"Dino",
+  "viewServiceOperationalStatus":"ENABLED",
+  "omagserverPlatformRootURL": "UNUSED",
+  "omagserverName" : "UNUSED",
+  "resourceEndpoints" : [
+    {
+        "class"              : "ResourceEndpointConfig",
+        "resourceCategory"   : "Platform",
+        "description"        : "Platform",
+        "platformName"       : "platform",
+        "platformRootURL"    : "${EGERIA_ENDPOINT}"
+    },
+    {
+        "class"              : "ResourceEndpointConfig",
+        "resourceCategory"   : "Server",
+        "serverInstanceName" : "${EGERIA_OMAG_SERVER_NAME}",
+        "description"        : "Server",
+        "platformName"       : "platform",
+        "serverName"         : "${EGERIA_OMAG_SERVER_NAME}"
+    },
+    {
+        "class"              : "ResourceEndpointConfig",
+        "resourceCategory"   : "Server",
+        "serverInstanceName" : "${EGERIA_VIEW_SERVER}",
+        "description"        : "Server",
+        "platformName"       : "platform",
+        "serverName"         : "${EGERIA_VIEW_SERVER}"
+    }
+  ]
+}
+EOF
+
+# Start up the view server
+echo -e '\n\n > Starting the view server:\n'
+curl -f -k --verbose --basic admin:admin -X POST --max-time 900 \
+    "${EGERIA_LOCAL_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_VIEW_SERVER}/instance"
+

--- a/charts/egeria-platform/scripts/run.sh
+++ b/charts/egeria-platform/scripts/run.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
+
 # split SERVER_LIST by ,
 SERVER_LIST_ARR=($(echo $SERVER_LIST | tr "," "\n"))
 

--- a/charts/egeria-platform/scripts/run.sh
+++ b/charts/egeria-platform/scripts/run.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# split SERVER_LIST by ,
+SERVER_LIST_ARR=($(echo $SERVER_LIST | tr "," "\n"))
+
+# loop server list and add servers to STARTUP_SERVER_LIST if present on file system
+# or to CONFIG_SERVER_LIST if they are not present
+STARTUP_SERVER_LIST=""
+CONFIG_SERVER_LIST=""
+for SERVER in "${SERVER_LIST_ARR[@]}";
+do
+    SERVER_CONFIG_PATH=/deployments/data/servers/${SERVER}
+    if [ -d "${SERVER_CONFIG_PATH}" ]
+    then
+        if [ -z "${STARTUP_SERVER_LIST}" ]
+        then
+            STARTUP_SERVER_LIST="${SERVER}"
+        else
+            STARTUP_SERVER_LIST="${STARTUP_SERVER_LIST},${SERVER}"
+        fi
+        echo "For server ${SERVER} found config in ${SERVER_CONFIG_PATH}. Added ${SERVER} to autostart: STARTUP_SERVER_LIST=${STARTUP_SERVER_LIST}";
+    else
+        if [ -z "${CONFIG_SERVER_LIST}" ]
+        then
+            CONFIG_SERVER_LIST="${SERVER}"
+        else
+            CONFIG_SERVER_LIST="${CONFIG_SERVER_LIST},${SERVER}"
+        fi
+        echo "For server ${SERVER} could not find config in ${SERVER_CONFIG_PATH}. Added ${SERVER} to config: CONFIG_SERVER_LIST=${CONFIG_SERVER_LIST}";
+    fi
+done
+
+# report result
+echo "STARTUP_SERVER_LIST=${STARTUP_SERVER_LIST}"
+echo "CONFIG_SERVER_LIST=${CONFIG_SERVER_LIST}"
+
+# make available
+export STARTUP_SERVER_LIST="${STARTUP_SERVER_LIST}"
+export CONFIG_SERVER_LIST="${CONFIG_SERVER_LIST}"
+
+# wait until Kafka is available
+echo "exit" | curl -m 2 -v telnet://${EGERIA_KAFKA_ENDPOINT}
+exit_code=$?
+echo "Wait until Kafka is ready..."
+until [ $exit_code -eq 0 ]; do
+    echo "Exit code for Kafka request: ${exit_code}"
+    sleep 4;
+    echo "exit" | curl -m 2 -v telnet://${EGERIA_KAFKA_ENDPOINT}
+    exit_code=$?
+done;
+echo "Kafka is available"
+
+# wait until base platform is ready if it is not self
+if [[ "${EGERIA_OMAG_SERVER_URL}" != "${EGERIA_ENDPOINT}" ]]
+then
+    echo "The OMAG Server runs on URL ${EGERIA_OMAG_SERVER_URL}, wait for it to come up..."
+    status_code=$(curl -s -o /dev/null -w "%{http_code}" -k -X GET ${EGERIA_OMAG_SERVER_URL}/open-metadata/platform-services/users/${EGERIA_USER}/server-platform/origin)
+    until [ $status_code -eq 200 ]; do
+        echo "Request to OMAG Server Platform: ${status_code}"
+        sleep 2;
+        status_code=$(curl -s -o /dev/null -w "%{http_code}" -k -X GET ${EGERIA_OMAG_SERVER_URL}/open-metadata/platform-services/users/${EGERIA_USER}/server-platform/origin)
+    done;
+    echo "OMAG Server is reachable under ${EGERIA_OMAG_SERVER_URL}"
+fi
+
+# start the config daemon if CONFIG_SERVER_LIST has entries
+if [ -n "${CONFIG_SERVER_LIST}" ]
+then
+    echo "Start config-daemon.sh"
+    /home/jboss/scripts/config-daemon.sh &
+else
+    # mark pod as ready after 20sec
+    # hopefully everything is loaded then
+    (sleep 20 && echo 'Done' > /tmp/done.txt) &
+fi
+
+# execute the original s2i run script
+# this will autload servers stored in STARTUP_SERVER_LIST
+exec /usr/local/s2i/run
+

--- a/charts/egeria-platform/templates/NOTES.txt
+++ b/charts/egeria-platform/templates/NOTES.txt
@@ -1,0 +1,5 @@
+A new Egeria Server Platform was started:
+- internal URL: {{ include "egeria-platform.ownPlatformUrl" . }}
+- external URL: {{ include "egeria-platform.fullname" . }}
+- image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+- autostart servers: {{ .Values.egeria.serverList }}

--- a/charts/egeria-platform/templates/_helpers.tpl
+++ b/charts/egeria-platform/templates/_helpers.tpl
@@ -1,0 +1,70 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "egeria-platform.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "egeria-platform.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "egeria-platform.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "egeria-platform.labels" -}}
+helm.sh/chart: {{ include "egeria-platform.chart" . }}
+{{ include "egeria-platform.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "egeria-platform.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "egeria-platform.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "egeria-platform.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "egeria-platform.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "egeria-platform.ownPlatformUrl" -}}
+https://{{ include "egeria-platform.fullname" . }}:{{ .Values.service.platformPort }}
+{{- end }}
+
+{{- define "egeria-platform.omagPlatformUrl" -}}
+{{- default (include "egeria-platform.ownPlatformUrl" .) .Values.egeria.omagServer.platformUrl }}
+{{- end }}

--- a/charts/egeria-platform/templates/_helpers.tpl
+++ b/charts/egeria-platform/templates/_helpers.tpl
@@ -1,3 +1,6 @@
+{{/* <!-- SPDX-License-Identifier: Apache-2.0 --> */}}
+{{/* Copyright Contributors to the Egeria project. */}}
+
 {{/*
 Expand the name of the chart.
 */}}

--- a/charts/egeria-platform/templates/configmap.yaml
+++ b/charts/egeria-platform/templates/configmap.yaml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "egeria-platform.fullname" . }}-config
+  labels:
+    {{- include "egeria-platform.labels" . | nindent 4 }}
+data:
+  # Disables strict checking by egeria of TLS certs. Needed for self-signed
+  STRICT_SSL: "false"
+  # Not set in values -- Only expected to be used for debugging. For regular use Audit Logs should be sufficient
+  {{ if .Values.egeria.logging }}
+  LOGGING_LEVEL_ROOT: {{ .Values.egeria.logging }}
+  {{ end }}
+  {{ if .Values.egeria.debug }}
+  JAVA_DEBUG: "true"
+  {{ end }}
+
+  # cluster internal URL for Egeria Platform
+  EGERIA_ENDPOINT: {{ include "egeria-platform.ownPlatformUrl" . }}
+  
+  # Egeria Endpoint on Localhost, used during startup
+  EGERIA_LOCAL_ENDPOINT: https://localhost:{{ .Values.service.platformPort }}
+  
+  # General Egeria Configuration
+  EGERIA_USER: {{ .Values.egeria.user }}
+  EGERIA_COHORT: {{ .Values.egeria.cohort }}
+  EGERIA_KAFKA_ENDPOINT: {{ .Values.egeria.kafkaEndpoint }}
+  EGERIA_VIEW_ORG: {{ .Values.egeria.viewOrg }}
+  EGERIA_LOADER_PATH: /extlib,/deployments/server/lib
+
+  # info to OMAG server
+  EGERIA_OMAG_SERVER_NAME: {{ .Values.egeria.omagServer.name }}
+  EGERIA_OMAG_SERVER_URL: {{ include "egeria-platform.omagPlatformUrl" . }}
+
+  # Autostart
+  SERVER_LIST: {{ .Values.egeria.serverList }}
+  
+  # Additional values inserted by user
+{{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 2 }}
+{{- end }}

--- a/charts/egeria-platform/templates/role.yaml
+++ b/charts/egeria-platform/templates/role.yaml
@@ -1,0 +1,10 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "egeria-platform.fullname" . }}-role
+  labels:
+    {{- include "egeria-platform.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints","pods","services","configmaps"]
+    verbs: ["get", "list", "watch","patch"]

--- a/charts/egeria-platform/templates/role.yaml
+++ b/charts/egeria-platform/templates/role.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/egeria-platform/templates/rolebindings.yaml
+++ b/charts/egeria-platform/templates/rolebindings.yaml
@@ -11,19 +11,3 @@ roleRef:
   kind: Role
   apiGroup: rbac.authorization.k8s.io
   name: {{ include "egeria-platform.fullname" . }}-role
----
-{{ if .Values.image.project }}
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: allow-pull-{{ include "egeria-platform.fullname" . }}-{{ .Release.Namespace }}
-  namespace: {{ .Values.image.project }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "egeria-platform.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: 'system:image-puller'
-{{- end }}

--- a/charts/egeria-platform/templates/rolebindings.yaml
+++ b/charts/egeria-platform/templates/rolebindings.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/egeria-platform/templates/rolebindings.yaml
+++ b/charts/egeria-platform/templates/rolebindings.yaml
@@ -1,0 +1,29 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "egeria-platform.fullname" . }}-rolebinding-rbac
+  labels:
+    {{- include "egeria-platform.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "egeria-platform.serviceAccountName" . }}
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ include "egeria-platform.fullname" . }}-role
+---
+{{ if .Values.image.project }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: allow-pull-{{ include "egeria-platform.fullname" . }}-{{ .Release.Namespace }}
+  namespace: {{ .Values.image.project }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "egeria-platform.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'system:image-puller'
+{{- end }}

--- a/charts/egeria-platform/templates/scripts.yaml
+++ b/charts/egeria-platform/templates/scripts.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/egeria-platform/templates/scripts.yaml
+++ b/charts/egeria-platform/templates/scripts.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "egeria-platform.fullname" . }}-scripts
+  labels:
+    {{- include "egeria-platform.labels" . | nindent 4 }}
+data:
+{{ (.Files.Glob "scripts/run.sh").AsConfig | indent 2 }}
+{{ (.Files.Glob "scripts/config-daemon.sh").AsConfig | indent 2 }}
+{{ (.Files.Glob "scripts/config-mds1.sh").AsConfig | indent 2 }}
+{{ (.Files.Glob "scripts/config-view1.sh").AsConfig | indent 2 }}

--- a/charts/egeria-platform/templates/service.yaml
+++ b/charts/egeria-platform/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "egeria-platform.fullname" . }}
+  labels:
+    {{- include "egeria-platform.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.platformPort }}
+      name: platform
+      targetPort: {{ .Values.service.platformPort }}
+    {{ if .Values.egeria.debug }}
+    - port: {{ .Values.service.debugPort }}
+      name: debug
+      targetPort: {{ .Values.service.debugPort }}
+    {{- end }}
+  selector:
+    {{- include "egeria-platform.selectorLabels" . | nindent 4 }}

--- a/charts/egeria-platform/templates/service.yaml
+++ b/charts/egeria-platform/templates/service.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/egeria-platform/templates/serviceaccount.yaml
+++ b/charts/egeria-platform/templates/serviceaccount.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/egeria-platform/templates/serviceaccount.yaml
+++ b/charts/egeria-platform/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "egeria-platform.serviceAccountName" . }}
+  labels:
+    {{- include "egeria-platform.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/egeria-platform/templates/statefulset.yaml
+++ b/charts/egeria-platform/templates/statefulset.yaml
@@ -4,11 +4,6 @@ metadata:
   name: {{ include "egeria-platform.fullname" . }}
   labels:
     {{- include "egeria-platform.labels" . | nindent 4 }}
-  {{ if .Values.image.project }}
-  annotations:
-    image.openshift.io/triggers: >-
-      [{"from":{"kind":"ImageStreamTag","name":"{{ last (splitList "/" .Values.image.repository) }}:{{ .Values.image.tag }}","namespace":"{{ .Values.image.project }}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"egeria\")].image"}]
-  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/egeria-platform/templates/statefulset.yaml
+++ b/charts/egeria-platform/templates/statefulset.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/egeria-platform/templates/statefulset.yaml
+++ b/charts/egeria-platform/templates/statefulset.yaml
@@ -1,0 +1,124 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "egeria-platform.fullname" . }}
+  labels:
+    {{- include "egeria-platform.labels" . | nindent 4 }}
+  {{ if .Values.image.project }}
+  annotations:
+    image.openshift.io/triggers: >-
+      [{"from":{"kind":"ImageStreamTag","name":"{{ last (splitList "/" .Values.image.repository) }}:{{ .Values.image.tag }}","namespace":"{{ .Values.image.project }}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"egeria\")].image"}]
+  {{- end }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  serviceName: {{ include "egeria-platform.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "egeria-platform.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "egeria-platform.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "egeria-platform.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: egeria
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "egeria-platform.fullname" . }}-config
+            {{ if .Values.secretName }}
+            - secretRef:
+                name: {{ .Values.secretName }}
+            {{- end }}
+          ports:
+            - containerPort: {{ .Values.service.platformPort }}
+              name: platform
+          {{ if .Values.egeria.debug }}
+            - containerPort: {{ .Values.service.debugPort }}
+              name: debug
+          {{ end }}
+          # No other checks until this passes
+          startupProbe:
+            exec:
+              command:
+                - stat
+                - /tmp/done.txt
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 1
+            failureThreshold: 25
+          # Is pod ready to service network requests - it will pause (for replicas, others will take the load)
+          readinessProbe:
+            httpGet:
+              path: /open-metadata/platform-services/users/{{ .Values.egeria.user }}/server-platform/origin
+              port: {{ .Values.service.platformPort }}
+              scheme: HTTPS
+            periodSeconds: 10
+            failureThreshold: 25
+          # Is pod doing useful work - if not we will restart it
+          livenessProbe:
+            httpGet:
+              path: /open-metadata/platform-services/users/{{ .Values.egeria.user }}/server-platform/origin
+              port: {{ .Values.service.platformPort }}
+              scheme: HTTPS
+            periodSeconds: 10
+            failureThreshold: 25
+          command: ["/home/jboss/scripts/run.sh"]
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{ if .Values.egeria.persistence }}
+          volumeMounts:
+            - mountPath: "/deployments/data"
+              # NO need to include release name in template - included as a SS
+              name: data
+            - mountPath: /home/jboss/scripts
+              name: configuration-scripts
+          {{ end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always
+      volumes:
+      - name: configuration-scripts
+        configMap:
+          name: {{ include "egeria-platform.fullname" . }}-scripts
+          defaultMode: 511
+  {{ if .Values.egeria.persistence }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .Values.egeria.storageSize}}
+      {{ if .Values.egeria.storageClass }}
+      storageClassName: {{ .Values.egeria.StorageClass }}
+      {{ end }}
+  {{ end }}

--- a/charts/egeria-platform/templates/tests/test-connection.yaml
+++ b/charts/egeria-platform/templates/tests/test-connection.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: quay.io/prometheus/busybox
       command: ['wget']
       args: ['{{ include "egeria-platform.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/charts/egeria-platform/templates/tests/test-connection.yaml
+++ b/charts/egeria-platform/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "egeria-platform.fullname" . }}-test-connection"
+  labels:
+    {{- include "egeria-platform.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "egeria-platform.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/egeria-platform/templates/tests/test-connection.yaml
+++ b/charts/egeria-platform/templates/tests/test-connection.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/egeria-platform/values.yaml
+++ b/charts/egeria-platform/values.yaml
@@ -46,9 +46,7 @@ image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "3.5-SNAPSHOT"
-  # load from OpenShift Project
-  project: ""
-
+  
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/egeria-platform/values.yaml
+++ b/charts/egeria-platform/values.yaml
@@ -1,0 +1,119 @@
+# Egeria Settings
+egeria:
+  # Global Egeria Settings
+  logging: error
+  version: "3.5"
+  debug: true
+
+  # persistence
+  persistence: true
+  storageClass: ibmc-vpc-block-10iops-tier
+  storageSize: 8Gi
+  repositoryType: "local-graph-repository"
+
+  # communication
+  cohort: mds
+  viewOrg: org
+  kafkaEndpoint: egeria-kafka:9092
+
+  # userid used for admin ops (no security enabled by default)
+  user: garygeeke
+
+  # list of servers that should start on this platform
+  # the names must correspond to a config-<name>.sh script
+  # as well as to the actual instance name
+  serverList: mds1,view1
+
+  # OMAG Server
+  # usually you need to configure a connection to an OMAG server
+  # the values below will result in EGERIA_OMAG_SERVER_NAME and EGERIA_OMAG_SERVER_URL environment variables
+  # if platformUrl is empty this will point to itself
+  omagServer:
+    name: mds1
+    platformUrl: ""
+    
+
+# Additional environment variables that are needed for setup the servers
+extraEnv: {}
+
+# name a secret to mount as environment variables to store secrets
+secretName: ""
+
+replicaCount: 1
+
+image:
+  repository: quay.io/odpi/egeria
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "3.5-SNAPSHOT"
+  # load from OpenShift Project
+  project: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 0
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  platformPort: 9443
+  debugPort: 5005
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  limits:
+    cpu: 1
+    memory: 700Mi
+  requests:
+    cpu: 1
+    memory: 700Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/egeria-platform/values.yaml
+++ b/charts/egeria-platform/values.yaml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
+
 # Egeria Settings
 egeria:
   # Global Egeria Settings

--- a/charts/egeria-platform/values.yaml
+++ b/charts/egeria-platform/values.yaml
@@ -2,12 +2,12 @@
 egeria:
   # Global Egeria Settings
   logging: error
-  version: "3.5"
+  version: "3.5-SNAPSHOT"
   debug: true
 
   # persistence
   persistence: true
-  storageClass: ibmc-vpc-block-10iops-tier
+  storageClass: default
   storageSize: 8Gi
   repositoryType: "local-graph-repository"
 

--- a/charts/egeria-presentation/.helmignore
+++ b/charts/egeria-presentation/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/egeria-presentation/.helmignore
+++ b/charts/egeria-presentation/.helmignore
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
+
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.

--- a/charts/egeria-presentation/Chart.yaml
+++ b/charts/egeria-presentation/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: egeria-presentation
-description: A Helm chart for Kubernetes
+description: Egeria presentation (reactUI) only
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/charts/egeria-presentation/Chart.yaml
+++ b/charts/egeria-presentation/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: egeria-presentation
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/egeria-presentation/Chart.yaml
+++ b/charts/egeria-presentation/Chart.yaml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
+
 apiVersion: v2
 name: egeria-presentation
 description: Egeria presentation (reactUI) only

--- a/charts/egeria-presentation/Chart.yaml
+++ b/charts/egeria-presentation/Chart.yaml
@@ -15,10 +15,18 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 3.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "3.4.0"
+keywords:
+  - odpi, egeria, presentation, react-ui
+icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
+sources:
+  - https://github.com/odpi/egeria-charts
+home: https://github.com/odpi/egeria-charts
+maintainers:
+  - name: Max Simon

--- a/charts/egeria-presentation/README.md
+++ b/charts/egeria-presentation/README.md
@@ -9,6 +9,8 @@ Use the following settings in `egeria-presentation` helm chart:
 - set `egeria.viewOrg` to the same viewOrg as the OMAG deployment (here `org`)
 - set `egeria.viewServerPlatformUrl` to the Egeria platform URL of `view1` (here `https://egeria-platform:9443`)
 
+Because the deployment needs access to the ConfigMap of the `egeria-platform`, it must be installed in the same namespace.
+
 Run
 ```
 helm install presentation ./egeria-presentation

--- a/charts/egeria-presentation/README.md
+++ b/charts/egeria-presentation/README.md
@@ -1,3 +1,6 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- # Copyright Contributors to the Egeria project. -->
+
 # egeria-presentation
 
 This repository is based on https://github.com/odpi/egeria-charts, but it only deploys the Egeria UI. This chart assumes that the platform of the view server was deployed using [egeria-platform](../egeria-platform/README.md).

--- a/charts/egeria-presentation/README.md
+++ b/charts/egeria-presentation/README.md
@@ -1,0 +1,16 @@
+# egeria-presentation
+
+This repository is based on https://github.com/odpi/egeria-charts, but it only deploys the Egeria UI. This chart assumes that the platform of the view server was deployed using [egeria-platform](../egeria-platform/README.md).
+
+## Deploy Egeria UI
+
+Use the following settings in `egeria-presentation` helm chart:
+- set `egeria.platformConfigMap` to the configmap of the Egeria OMAG deployment (here `egeria-platform-config`)
+- set `egeria.viewOrg` to the same viewOrg as the OMAG deployment (here `org`)
+- set `egeria.viewServerPlatformUrl` to the Egeria platform URL of `view1` (here `https://egeria-platform:9443`)
+
+Run
+```
+helm install presentation ./egeria-presentation
+```
+to create the Egeria UI deployment.

--- a/charts/egeria-presentation/templates/NOTES.txt
+++ b/charts/egeria-presentation/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "egeria-presentation.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "egeria-presentation.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "egeria-presentation.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "egeria-presentation.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/egeria-presentation/templates/_helpers.tpl
+++ b/charts/egeria-presentation/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "egeria-presentation.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "egeria-presentation.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "egeria-presentation.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "egeria-presentation.labels" -}}
+helm.sh/chart: {{ include "egeria-presentation.chart" . }}
+{{ include "egeria-presentation.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "egeria-presentation.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "egeria-presentation.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "egeria-presentation.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "egeria-presentation.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/egeria-presentation/templates/_helpers.tpl
+++ b/charts/egeria-presentation/templates/_helpers.tpl
@@ -1,3 +1,6 @@
+{{/* <!-- SPDX-License-Identifier: Apache-2.0 --> */}}
+{{/* Copyright Contributors to the Egeria project. */}}
+
 {{/*
 Expand the name of the chart.
 */}}

--- a/charts/egeria-presentation/templates/deployment.yaml
+++ b/charts/egeria-presentation/templates/deployment.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "egeria-presentation.fullname" . }}
+  labels:
+    {{- include "egeria-presentation.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "egeria-presentation.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "egeria-presentation.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "egeria-presentation.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.egeria.platformConfigMap }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: EGERIA_PRESENTATIONSERVER_SERVER_{{ .Values.egeria.viewOrg }}
+              value: '{"remoteServerName":"{{ .Values.egeria.viewServer }}","remoteURL":"{{ .Values.egeria.viewServerPlatformUrl }}"}'
+            - name: VIEW_ORG
+              value: {{ .Values.egeria.viewOrg }}
+          ports:
+            - name: presentation
+              containerPort: 8091
+              protocol: TCP
+          # No other checks until this passes
+          startupProbe:
+            tcpSocket:
+              port: 8091
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 15
+          # Is pod ready to service network requests - it will pause (for replicas, others will take the load)
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8091
+              scheme: HTTPS
+            periodSeconds: 10
+            failureThreshold: 6
+          # Is pod doing useful work - if not we will restart it
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8091
+              scheme: HTTPS
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/egeria-presentation/templates/deployment.yaml
+++ b/charts/egeria-presentation/templates/deployment.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/egeria-presentation/templates/ingress.yaml
+++ b/charts/egeria-presentation/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "egeria-presentation.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "egeria-presentation.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/egeria-presentation/templates/ingress.yaml
+++ b/charts/egeria-presentation/templates/ingress.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "egeria-presentation.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}

--- a/charts/egeria-presentation/templates/service.yaml
+++ b/charts/egeria-presentation/templates/service.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/egeria-presentation/templates/service.yaml
+++ b/charts/egeria-presentation/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "egeria-presentation.fullname" . }}
+  labels:
+    {{- include "egeria-presentation.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      name: presentation
+      targetPort: {{ .Values.service.port }}
+  selector:
+    {{- include "egeria-presentation.selectorLabels" . | nindent 4 }}

--- a/charts/egeria-presentation/templates/serviceaccount.yaml
+++ b/charts/egeria-presentation/templates/serviceaccount.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/egeria-presentation/templates/serviceaccount.yaml
+++ b/charts/egeria-presentation/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "egeria-presentation.serviceAccountName" . }}
+  labels:
+    {{- include "egeria-presentation.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/egeria-presentation/templates/tests/test-connection.yaml
+++ b/charts/egeria-presentation/templates/tests/test-connection.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: quay.io/prometheus/busybox
       command: ['wget']
       args: ['{{ include "egeria-presentation.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/charts/egeria-presentation/templates/tests/test-connection.yaml
+++ b/charts/egeria-presentation/templates/tests/test-connection.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/egeria-presentation/templates/tests/test-connection.yaml
+++ b/charts/egeria-presentation/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "egeria-presentation.fullname" . }}-test-connection"
+  labels:
+    {{- include "egeria-presentation.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "egeria-presentation.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/egeria-presentation/values.yaml
+++ b/charts/egeria-presentation/values.yaml
@@ -1,0 +1,91 @@
+# Default values for egeria-presentation.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+
+egeria:
+  platformConfigMap: egeria-platform-config
+  # TODO: this can be fetched from platformConfigMap
+  # only required for EGERIA_PRESENTATIONSERVER_SERVER_{{ .Values.egeria.viewOrg }}
+  viewOrg: org
+  viewServer: view1
+  viewServerPlatformUrl: https://egeria-platform:9443
+
+replicaCount: 1
+
+image:
+  repository: quay.io/odpi/egeria-react-ui
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "3.4.0"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 8091
+
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/egeria-presentation/values.yaml
+++ b/charts/egeria-presentation/values.yaml
@@ -1,7 +1,5 @@
-# Default values for egeria-presentation.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
 
 egeria:
   platformConfigMap: egeria-platform-config


### PR DESCRIPTION
This pull request adds two new charts:
- `egeria-platform`: a reusable chart to deploy server platforms with different servers running on them
- `egeria-presentation`: a chart to deploy the [Egeria UI](https://github.com/odpi/egeria-react-ui)

## egeria-platform

The chart is based on `egeria-base` but has the following major changes:
- Instead of running an external job to configure the platform and the servers, the scripts are running from inside the container. This allows to use `localhost` so that the service (and the pod itself) does not need to be marked as ready during configuration. In addition, the scripts can be part of the container image which might be easier to maintain.
- The container decides if it loads configuration files from a PV or if it executes the configuration script. By this, the configuration map with `STARTUP_SERVER_LIST` does not need to be updated and gets stateless again.
- Kafka was removed as a dependency. This allows to deploy multiple instances of this chart into the same namespace.
- The pod supports Kubernetes probes.

The aim of these changes is to allow for an environment where each server can run on its own server platform in a Kubernetes pod. This allows for fewer resource consumption and an easier maintenance on Kubernetes.

## egeria-presentation

The chart is based on `egeria-base` but only deploys the UI component. It is useful to do this seperately if multiple server platforms with different servers are deployed.

The chart only requires the following configuration for Egeria:
- the URL of the OMAG server
- the name of the view server (`view1`)
- a reference to the configuration map deployed with the `egeria-platform` chart

Note that the environment variable `EGERIA_PRESENTATIONSERVER_SERVER_<organisation>` is set by Helm and does not require an update of configuration maps anymore.

