### PR TITLE
Use strimzi for egeria-base chart

### DIFF
--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -2,9 +2,9 @@
 # Copyright Contributors to the Egeria project.
 ---
 name: egeria-base
-description: Egeria simple deployment to Kubernetes
+description: Egeria simple deployment (platform, react UI)
 apiVersion: v2
-version: 3.4.0
+version: 3.4.1-prelease.0
 appVersion: 3.4
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
@@ -16,6 +16,6 @@ maintainers:
   - name: Nigel Jones
     email: nigel.l.jones+git@gmail.com
 dependencies:
-  - name: kafka
-    version: 14.4.1
-    repository: https://charts.bitnami.com/bitnami
+  - name: strimzi-kafka-operator
+    version: 0.26.1
+    repository: https://strimzi.io/charts/

--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-base
 description: Egeria simple deployment (platform, react UI)
 apiVersion: v2
-version: 3.4.1-prelease.0
+version: 3.4.1-prelease.1
 appVersion: 3.4
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-base/templates/_helpers.tpl
+++ b/charts/egeria-base/templates/_helpers.tpl
@@ -46,6 +46,5 @@ Create the name of the service account to use
 
 {{- define "egeria.security" -}}
 serviceAccountName: {{ template "mychart.serviceAccountName" . }}
-securityContext:
-  fsGroup: 0
+
 {{- end }}

--- a/charts/egeria-base/templates/config.yaml
+++ b/charts/egeria-base/templates/config.yaml
@@ -44,7 +44,7 @@ spec:
           imagePullPolicy: {{ (.Values.image.configure.pullPolicy | default .Values.imageDefaults.pullPolicy) | default (ternary "Always" "IfNotPresent" ( hasSuffix "SNAPSHOT" (.Values.image.configure.tag | default .Values.egeria.version )))  }}
           env:
             - name: SERVICE
-              value: {{ .Release.Name }}-kafka
+              value: {{ .Release.Name }}-strimzi-kafka-bootstrap
       containers:
         - name: initialize
           image: "{{ if (.Values.image.configure.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.configure.registry | default .Values.imageDefaults.registry }}/{{ end }}\

--- a/charts/egeria-base/templates/env.yaml
+++ b/charts/egeria-base/templates/env.yaml
@@ -20,7 +20,7 @@ data:
   EGERIA_ENDPOINT: https://{{ .Release.Name }}-platform:9443
   EGERIA_USER: {{ .Values.egeria.user }}
   EGERIA_COHORT: {{ .Values.egeria.cohort }}
-  KAFKA_ENDPOINT: {{ .Release.Name }}-kafka:9092
+  KAFKA_ENDPOINT: {{ .Release.Name }}-strimzi-kafka-bootstrap:9092
   EGERIA_SERVER: {{ .Values.egeria.serverName }}
   VIEW_SERVER: {{ .Values.egeria.viewServerName }}
   EGERIA_PRESENTATIONSERVER_SERVER_{{ .Values.egeria.viewOrg }}: "{\"remoteServerName\":\"{{ .Values.egeria.viewServerName }}\",\"remoteURL\":\"https://{{ .Release.Name }}-platform:9443\"}"

--- a/charts/egeria-base/templates/kafka-cluster.yaml
+++ b/charts/egeria-base/templates/kafka-cluster.yaml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+  # Copyright Contributors to the Egeria project.
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: {{ .Release.Name }}-strimzi
+spec:
+  kafka:
+    version: 3.0.0
+    replicas: 1
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      log.message.format.version: "3.0"
+      inter.broker.protocol.version: "3.0"
+      auto.create.topics.enable: "true"
+    readinessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    livenessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    storage:
+      type: jbod
+      volumes:
+        - id: 0
+          type: persistent-claim
+          size: 5Gi
+          deleteClaim: true
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: 1Gi
+      deleteClaim: true
+  entityOperator:
+    topicOperator:
+      reconciliationIntervalSeconds: 20
+    userOperator: 
+      reconciliationIntervalSeconds: 20

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v1
-version: 3.4.1-prerelease.2
+version: 3.4.1-prerelease.3
 appVersion: 3.4
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v1
-version: 3.4.1-prerelease.3
+version: 3.4.1-prerelease.4
 appVersion: 3.4
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/etc/default.conf.template
+++ b/charts/odpi-egeria-lab/etc/default.conf.template
@@ -1,8 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the Egeria project.
+
+#pid        /tmp/nginx.pid;
+
+#http {
+#    client_body_temp_path /tmp/client_temp;
+#    proxy_temp_path       /tmp/proxy_temp_path;
+#    fastcgi_temp_path     /tmp/fastcgi_temp;
+#    uwsgi_temp_path       /tmp/uwsgi_temp;
+#    scgi_temp_path        /tmp/scgi_temp;
+#}
+
 server {
 
-    listen                443 ssl;
+    listen                8443 ssl;
     #listen                 80;
     server_name           ${NGINX_SERVER_NAME};
     ssl_certificate       /etc/nginx/ssl/tls.crt;

--- a/charts/odpi-egeria-lab/etc/staticui.conf.template
+++ b/charts/odpi-egeria-lab/etc/staticui.conf.template
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project
+
+server {
+    listen 8080;
+    server_name _;
+
+    root /var/www/;
+    index index.html;
+
+    # Force all paths to load either itself (js files) or go through index.html.
+    location / {
+        try_files $uri /index.html;
+    }
+}

--- a/charts/odpi-egeria-lab/templates/_helpers.tpl
+++ b/charts/odpi-egeria-lab/templates/_helpers.tpl
@@ -32,7 +32,18 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mychart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "myapp.name" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+
 {{- define "egeria.security" -}}
-securityContext:
-  fsGroup: 0
+serviceAccountName: {{ template "mychart.serviceAccountName" . }}
 {{- end }}

--- a/charts/odpi-egeria-lab/templates/egeria-nginx.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-nginx.yaml
@@ -1,7 +1,46 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the Egeria project.
 ---
+# Configmap needed to store 'base' nginx configuration - needed to ensure all the paths
+# used are writeable when running unpriviliged. The actual server config is
+# defined in an included template
 {{ if .Values.egeria.egeriaui }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "myapp.name" . }}
+    helm.sh/chart: {{ include "myapp.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: nginx-conf
+  name: {{ .Release.Name }}-nginx-conf
+data:
+  nginx.conf: |
+    # SPDX-License-Identifier: Apache-2.0
+    # Copyright Contributors to the Egeria project.
+    worker_processes  auto;
+    error_log  /var/log/nginx/error.log notice;
+    events {
+      worker_connections  1024;
+    }
+    pid        /tmp/nginx.pid;
+    http {
+      include       /etc/nginx/mime.types;
+      default_type  application/octet-stream;
+      log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+      access_log  /var/log/nginx/access.log  main;
+      sendfile        on;
+      keepalive_timeout  65;
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path       /tmp/proxy_temp_path;
+      fastcgi_temp_path     /tmp/fastcgi_temp;
+      uwsgi_temp_path       /tmp/uwsgi_temp;
+      scgi_temp_path        /tmp/scgi_temp;
+      include /etc/nginx/conf.d/*.conf;
+    }
+...
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -64,10 +103,10 @@ spec:
                   {{ if (.Values.image.nginx.tag) }}:{{ .Values.image.nginx.tag }}{{ end }}"
           imagePullPolicy: {{ .Values.image.nginx.pullPolicy | default .Values.imageDefaults.pullPolicy | default "IfNotPresent" }}
           ports:
-            - containerPort: 443
+            - containerPort: 8443
           readinessProbe:
             tcpSocket:
-              port: 443
+              port: 8443
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 6
@@ -82,6 +121,11 @@ spec:
           volumeMounts:
             - name: template-vol
               mountPath: /etc/nginx/templates
+            - name: conf-vol
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: confd-vol
+              mountPath: /etc/nginx/conf.d
             - name: ssl-vol
               mountPath: /etc/nginx/ssl
             - name: pass-vol
@@ -91,6 +135,13 @@ spec:
         - name: template-vol
           configMap:
             name: {{ .Release.Name }}-template-configmap
+        # default config file - read only (configmap)
+        - name: conf-vol
+          configMap:
+            name: {{ .Release.Name }}-nginx-conf
+        # Created each time, so an empty local directory is suitable. Must be writeable
+        - name: confd-vol
+          emptyDir: {}
         - name: ssl-vol
           secret:
             secretName: {{ .Release.Name }}-nginx-ssl

--- a/charts/odpi-egeria-lab/templates/egeria-nginx.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-nginx.yaml
@@ -113,7 +113,7 @@ spec:
           resources: {}
           env:
             - name: UI_STATIC
-              value: http://{{ .Release.Name }}-uistatic:80
+              value: http://{{ .Release.Name }}-uistatic:8080
             - name: UI_API
               value: https://{{ .Release.Name }}-ui:8443
             - name: NGINX_SERVER_NAME
@@ -168,10 +168,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: etc
   name: {{ .Release.Name }}-template-configmap
-{{- if and (.Files.Glob "etc/**") }}
+{{- if and (.Files.Glob "etc/default.conf.template") }}
 binaryData:
   {{- $root := . }}
-  {{- range $path, $bytes := .Files.Glob "etc/**" }}
+  {{- range $path, $bytes := .Files.Glob "etc/default.conf.template" }}
   {{ base $path }}: {{ $root.Files.Get $path | b64enc | quote }}
   {{- end }}
   {{- end }}

--- a/charts/odpi-egeria-lab/templates/egeria-uistatic.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-uistatic.yaml
@@ -1,6 +1,42 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the Egeria project.
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "myapp.name" . }}
+    helm.sh/chart: {{ include "myapp.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: uistatic-nginx-conf
+  name: {{ .Release.Name }}-uistatic-nginx-conf
+data:
+  nginx.conf: |
+    # SPDX-License-Identifier: Apache-2.0
+    # Copyright Contributors to the Egeria project.
+    worker_processes  auto;
+    error_log  /var/log/nginx/error.log notice;
+    events {
+      worker_connections  1024;
+    }
+    pid        /tmp/nginx.pid;
+    http {
+      include       /etc/nginx/mime.types;
+      default_type  application/octet-stream;
+      log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+      access_log  /var/log/nginx/access.log  main;
+      sendfile        on;
+      keepalive_timeout  65;
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path       /tmp/proxy_temp_path;
+      fastcgi_temp_path     /tmp/fastcgi_temp;
+      uwsgi_temp_path       /tmp/uwsgi_temp;
+      scgi_temp_path        /tmp/scgi_temp;
+      include /etc/nginx/conf.d/*.conf;
+    }
+...
+---
 {{ if .Values.egeria.egeriaui }}
 apiVersion: v1
 kind: Service
@@ -63,10 +99,10 @@ spec:
                   :{{ .Values.image.uistatic.tag | default .Values.egeria.version }}"
           imagePullPolicy: {{ .Values.image.uistatic.pullPolicy | default .Values.imageDefaults.pullPolicy | default "IfNotPresent" }}
           ports:
-            - containerPort: 80
+            - containerPort: 8080
           readinessProbe:
             tcpSocket:
-              port: 80
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 6
@@ -74,8 +110,46 @@ spec:
           #env:
           #  - name: EGERIA_PRESENTATIONSERVER_SERVER_coco
           #    value: "{\"remoteServerName\":\"cocoView1\",\"remoteURL\":\"https://{{ .Release.Name }}-datalake:9443\"}"
+          volumeMounts:
+            - name: template-vol
+              mountPath: /etc/nginx/templates
+            - name: conf-vol
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: confd-vol
+              mountPath: /etc/nginx/conf.d
       restartPolicy: Always
+      volumes:
+        - name: template-vol
+          configMap:
+            name: {{ .Release.Name }}-uistatic-template-configmap
+        # default config file - read only (configmap)
+        - name: conf-vol
+          configMap:
+            name: {{ .Release.Name }}-uistatic-nginx-conf
+        # Created each time, so an empty local directory is suitable. Must be writeable
+        - name: confd-vol
+          emptyDir: { }
 
 status: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "myapp.name" . }}
+    helm.sh/chart: {{ include "myapp.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: etc
+  name: {{ .Release.Name }}-uistatic-template-configmap
+{{- if and (.Files.Glob "etc/staticui.conf.template") }}
+binaryData:
+  {{- $root := . }}
+  {{- range $path, $bytes := .Files.Glob "etc/staticui.conf.template" }}
+  {{ base $path }}: {{ $root.Files.Get $path | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+
 ...
 {{ end }}

--- a/charts/odpi-egeria-lab/templates/jupyter.yaml
+++ b/charts/odpi-egeria-lab/templates/jupyter.yaml
@@ -54,8 +54,6 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: jupyter
     spec:
-      securityContext:
-        fsGroup: 100
       containers:
         - name: jupyter
           image: "{{ if (.Values.image.jupyter.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.jupyter.registry | default .Values.imageDefaults.registry }}/{{ end }}\

--- a/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
+++ b/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
@@ -34,22 +34,12 @@ spec:
           type: persistent-claim
           size: 5Gi
           deleteClaim: true
-    template:
-      pod:
-        securityContext:
-          runAsUser: 1001
-          fsGroup: 0
   zookeeper:
     replicas: 1
     storage:
       type: persistent-claim
       size: 1Gi
       deleteClaim: true
-    template:
-      pod:
-        securityContext:
-          runAsUser: 1001
-          fsGroup: 0
   entityOperator:
     topicOperator:
       reconciliationIntervalSeconds: 20

--- a/charts/odpi-egeria-lab/templates/rbac.yaml
+++ b/charts/odpi-egeria-lab/templates/rbac.yaml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
+{{ if .Values.rbac.create }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "myapp.name" . }}
+    helm.sh/chart: {{ include "myapp.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: egeria-rbac
+  name: {{ include "myapp.name" . }}-api-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints","pods","services","configmaps"]
+    verbs: ["get", "list", "watch","patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "myapp.name" . }}
+    helm.sh/chart: {{ include "myapp.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: egeria-rbac
+  name: {{ include "myapp.name" . }}-api-role-binding
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "mychart.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ include "myapp.name" . }}-api-role
+{{ end }}

--- a/charts/odpi-egeria-lab/templates/serviceAccount.yaml
+++ b/charts/odpi-egeria-lab/templates/serviceAccount.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
+{{ if .Values.serviceAccount.create }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "myapp.name" . }}
+    helm.sh/chart: {{ include "myapp.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: egeria-rbac
+  name: {{ template "mychart.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -69,6 +69,7 @@ image:
     name: egeria-configure
   jupyter:
     name: jupyter
+    tag: "latest"
   uistatic:
     name: egeria-ui
     tag: "3.2.0"

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -75,8 +75,19 @@ image:
   nginx:
     registry: public.ecr.aws
     name: nginx/nginx
-    tag: latest
+    tag: "stable"
 
+# Standard helm best practice
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
 
 # --- 
 # Persistence


### PR DESCRIPTION
* #101
  - Updates egeria-base chart to use 'strimzi' for kafka
* #18
  - Updates egeria-base chart to work within the default, restricted security context on openshift 
  - Updates nginx to run unpriviliged (no extra k8s privileges needed) 
  - Updates egeria-ui container to run unpriviliged (see also https://github.com/odpi/egeria-ui/issues/289 )
  - Updates strimzi config (above) to not require priv
  - Removes fsGroup override from jupyter container, to also allow unpriv use (see odpi/egeria#6049 )
  - updates chart to use new jupyter image
  - adds serviceAccount to enable extra permissions to be added if needed
* Also
  - increments chart versions for affected charts