### PR TITLE
Use matching ports

### DIFF
--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v1
-version: 3.4.1-prerelease.4
+version: 3.4.1-prerelease.5
 appVersion: 3.4
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/templates/egeria-nginx.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-nginx.yaml
@@ -56,7 +56,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: 443
-      targetPort: 443
+      targetPort: 8443
       {{- if ( eq  .Values.service.type "NodePort" ) }}
       nodePort: {{ .Values.service.nodeport.nginx }}
       {{- end }}

--- a/charts/odpi-egeria-lab/templates/egeria-uistatic.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-uistatic.yaml
@@ -52,8 +52,8 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: 80
-      targetPort: 80
+    - port: 8080
+      targetPort: 8080
       {{- if ( eq  .Values.service.type "NodePort" ) }}
       nodePort: {{ .Values.service.nodeport.uistatic }}
       {{- end }}


### PR DESCRIPTION
After nginx configuration changes some internal ports were mismatching breaking the Egeria UI configuration.
These changes were tested locally running microk8s on mac x86-64

Signed-off-by: Ljupcho Palashevski <ljupcho.palashevski@ing.com>