### PR TITLE
Release charts 3.4.1

### DIFF
--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-base
 description: Egeria simple deployment (platform, react UI)
 apiVersion: v2
-version: 3.4.1-prelease.3
+version: 3.4.1
 appVersion: 3.4
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v1
-version: 3.4.1-prerelease.6
+version: 3.4.1
 appVersion: 3.4
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:


### PR DESCRIPTION
odpi-egeria-lab, egeria-base are released at 3.4.1

Now supports Apple silicon / m1 / arm64 
 - all Egeria containers available in amd64 & arm64
 - migrated Kafka support to Strimzi