### PR TITLE
#3 enable spec of additional connectors for download in lab chart

### DIFF
--- a/charts/odpi-egeria-lab/templates/egeria-core.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-core.yaml
@@ -63,6 +63,34 @@ spec:
         app.kubernetes.io/component: core
     spec:
     {{- include "egeria.security" . | nindent 6 }}
+    spec:
+      volumes:
+        - name: egeria-connector-volume
+          emptyDir: {}
+{{ if .Values.downloads }}
+      initContainers:
+        - name: init-connector
+          image: "{{ if (.Values.image.configure.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.configure.registry | default .Values.imageDefaults.registry }}/{{ end }}\
+                  {{ if (.Values.image.configure.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.configure.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
+                  {{ .Values.image.configure.name }}\
+                  :{{ .Values.image.configure.tag | default .Values.imageDefaults.tag }}"
+          imagePullPolicy: {{ .Values.image.configure.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Release.Name }}-env
+          command:
+            - "/bin/bash"
+            - "-c"
+            - >
+                cd /opt/egeria/connectors &&
+{{ range .Values.downloads }}
+                curl --location {{ .url | quote }} --output {{ .filename | quote }} &&
+{{ end }}
+                echo "Downloads complete."
+          volumeMounts:
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+{{ end }}
       containers:
         - name: egeria
           image: "{{ if (.Values.image.egeria.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.egeria.registry | default .Values.imageDefaults.registry }}/{{ end }}\
@@ -78,6 +106,8 @@ spec:
             - name: JAVA_DEBUG
               value:  "true"
             {{ end }}
+            - name: "LOADER_PATH"
+              value: "/deployments/server/lib,/opt/egeria/connectors"
           ports:
             - containerPort: 9443
           {{ if .Values.debug.egeriaJVM }}
@@ -90,11 +120,14 @@ spec:
             periodSeconds: 10
             failureThreshold: 6
           resources: {}
-          {{ if .Values.persistence.enabled }}
           volumeMounts:
+          {{ if .Values.persistence.enabled }}
             - mountPath: "/deployments/data"
               name: {{ .Release.Name }}-core-data
           {{ end }}
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+              readOnly: true
       restartPolicy: Always
   {{ if .Values.persistence.enabled }}
   volumeClaimTemplates:
@@ -108,4 +141,5 @@ spec:
           storage: 8Gi
       #storageClassName:
   {{ end }}
+
 ...

--- a/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
@@ -9,8 +9,8 @@ metadata:
     helm.sh/chart: {{ include "myapp.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/component: datalake
-  name: {{ .Release.Name }}-datalake
+    app.kubernetes.io/component: core
+  name: {{ .Release.Name }}-core
 
 spec:
   type: {{ .Values.service.type }}
@@ -18,51 +18,79 @@ spec:
     - port: 9443
       targetPort: 9443
       {{- if ( eq  .Values.service.type "NodePort" ) }}
-      nodePort: {{ .Values.service.nodeport.datalake }}
+      nodePort: {{ .Values.service.nodeport.core }}
       {{- end }}
-    {{ if .Values.debug.egeriaJVM }}
+  {{ if .Values.debug.egeriaJVM }}
     - name: debug
       port: 5005
       targetPort: 5005
       {{- if ( eq  .Values.service.type "NodePort" ) }}
-      nodePort: {{ .Values.service.nodeport.debug.datalake }}
+      nodePort: {{ .Values.service.nodeport.debug.core }}
       {{- end }}
-    {{ end }}
+  {{ end }}
   selector:
     app.kubernetes.io/name: {{ include "myapp.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: datalake
+    app.kubernetes.io/component: core
 ...
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   creationTimestamp: null
-  name: {{ include "myapp.fullname" . }}-datalake
+  name: {{ include "myapp.fullname" . }}-core
   labels:
     app.kubernetes.io/name: {{ include "myapp.name" . }}
     helm.sh/chart: {{ include "myapp.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/component: datalake
+    app.kubernetes.io/component: core
 
 spec:
   replicas: 1
-  serviceName: {{ .Release.Name }}-datalake
+  serviceName: {{ .Release.Name }}-core
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "myapp.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: datalake
+      app.kubernetes.io/component: core
   template:
     metadata:
       creationTimestamp: null
       labels:
         app.kubernetes.io/name: {{ include "myapp.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/component: datalake
+        app.kubernetes.io/component: core
     spec:
-      {{- include "egeria.security" . | nindent 6 }}
+    {{- include "egeria.security" . | nindent 6 }}
+    spec:
+      volumes:
+        - name: egeria-connector-volume
+          emptyDir: {}
+{{ if .Values.downloads }}
+      initContainers:
+        - name: init-connector
+          image: "{{ if (.Values.image.configure.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.configure.registry | default .Values.imageDefaults.registry }}/{{ end }}\
+                  {{ if (.Values.image.configure.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.configure.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
+                  {{ .Values.image.configure.name }}\
+                  :{{ .Values.image.configure.tag | default .Values.imageDefaults.tag }}"
+          imagePullPolicy: {{ .Values.image.configure.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Release.Name }}-env
+          command:
+            - "/bin/bash"
+            - "-c"
+            - >
+                cd /opt/egeria/connectors &&
+{{ range .Values.downloads }}
+                curl --location {{ .url | quote }} --output {{ .filename | quote }} &&
+{{ end }}
+                echo "Downloads complete."
+          volumeMounts:
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+{{ end }}
       containers:
         - name: egeria
           image: "{{ if (.Values.image.egeria.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.egeria.registry | default .Values.imageDefaults.registry }}/{{ end }}\
@@ -78,6 +106,8 @@ spec:
             - name: JAVA_DEBUG
               value:  "true"
             {{ end }}
+            - name: "LOADER_PATH"
+              value: "/deployments/server/lib,/opt/egeria/connectors"
           ports:
             - containerPort: 9443
           {{ if .Values.debug.egeriaJVM }}
@@ -90,22 +120,26 @@ spec:
             periodSeconds: 10
             failureThreshold: 6
           resources: {}
-          {{ if .Values.persistence.enabled }}
           volumeMounts:
+          {{ if .Values.persistence.enabled }}
             - mountPath: "/deployments/data"
-              name: {{ .Release.Name }}-datalake-data
+              name: {{ .Release.Name }}-core-data
           {{ end }}
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+              readOnly: true
       restartPolicy: Always
   {{ if .Values.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
-        name: {{ .Release.Name }}-datalake-data
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 8Gi
-        #storageClassName:
+  - metadata:
+      name: {{ .Release.Name }}-core-data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 8Gi
+      #storageClassName:
   {{ end }}
+
 ...

--- a/charts/odpi-egeria-lab/templates/egeria-dev.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-dev.yaml
@@ -9,61 +9,88 @@ metadata:
     helm.sh/chart: {{ include "myapp.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/component: dev
-  name: {{ .Release.Name }}-dev
+    app.kubernetes.io/component: core
+  name: {{ .Release.Name }}-core
 
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - name: https
-      port: 9443
+    - port: 9443
       targetPort: 9443
       {{- if ( eq  .Values.service.type "NodePort" ) }}
-      nodePort: {{ .Values.service.nodeport.dev }}
+      nodePort: {{ .Values.service.nodeport.core }}
       {{- end }}
-    {{ if .Values.debug.egeriaJVM }}
+  {{ if .Values.debug.egeriaJVM }}
     - name: debug
       port: 5005
       targetPort: 5005
       {{- if ( eq  .Values.service.type "NodePort" ) }}
-      nodePort: {{ .Values.service.nodeport.debug.dev }}
+      nodePort: {{ .Values.service.nodeport.debug.core }}
       {{- end }}
-    {{ end }}
+  {{ end }}
   selector:
     app.kubernetes.io/name: {{ include "myapp.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: dev
+    app.kubernetes.io/component: core
 ...
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   creationTimestamp: null
-  name: {{ include "myapp.fullname" . }}-dev
+  name: {{ include "myapp.fullname" . }}-core
   labels:
     app.kubernetes.io/name: {{ include "myapp.name" . }}
     helm.sh/chart: {{ include "myapp.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/component: dev
+    app.kubernetes.io/component: core
 
 spec:
   replicas: 1
-  serviceName: {{ .Release.Name }}-dev
+  serviceName: {{ .Release.Name }}-core
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "myapp.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: dev
+      app.kubernetes.io/component: core
   template:
     metadata:
       creationTimestamp: null
       labels:
         app.kubernetes.io/name: {{ include "myapp.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/component: dev
+        app.kubernetes.io/component: core
     spec:
-      {{- include "egeria.security" . | nindent 6 }}
+    {{- include "egeria.security" . | nindent 6 }}
+    spec:
+      volumes:
+        - name: egeria-connector-volume
+          emptyDir: {}
+{{ if .Values.downloads }}
+      initContainers:
+        - name: init-connector
+          image: "{{ if (.Values.image.configure.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.configure.registry | default .Values.imageDefaults.registry }}/{{ end }}\
+                  {{ if (.Values.image.configure.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.configure.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
+                  {{ .Values.image.configure.name }}\
+                  :{{ .Values.image.configure.tag | default .Values.imageDefaults.tag }}"
+          imagePullPolicy: {{ .Values.image.configure.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Release.Name }}-env
+          command:
+            - "/bin/bash"
+            - "-c"
+            - >
+                cd /opt/egeria/connectors &&
+{{ range .Values.downloads }}
+                curl --location {{ .url | quote }} --output {{ .filename | quote }} &&
+{{ end }}
+                echo "Downloads complete."
+          volumeMounts:
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+{{ end }}
       containers:
         - name: egeria
           image: "{{ if (.Values.image.egeria.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.egeria.registry | default .Values.imageDefaults.registry }}/{{ end }}\
@@ -76,14 +103,16 @@ spec:
                 name: {{ include "myapp.fullname" . }}-configmap
           env:
             {{ if .Values.debug.egeriaJVM }}
-             - name: JAVA_DEBUG
-               value:  "true"
+            - name: JAVA_DEBUG
+              value:  "true"
             {{ end }}
+            - name: "LOADER_PATH"
+              value: "/deployments/server/lib,/opt/egeria/connectors"
           ports:
             - containerPort: 9443
-            {{ if .Values.debug.egeriaJVM }}
+          {{ if .Values.debug.egeriaJVM }}
             - containerPort: 5005
-            {{ end }}
+          {{ end }}
           readinessProbe:
             tcpSocket:
               port: 9443
@@ -91,22 +120,26 @@ spec:
             periodSeconds: 10
             failureThreshold: 6
           resources: {}
-          {{ if .Values.persistence.enabled }}
           volumeMounts:
+          {{ if .Values.persistence.enabled }}
             - mountPath: "/deployments/data"
-              name: {{ .Release.Name }}-dev-data
-         {{ end }}
+              name: {{ .Release.Name }}-core-data
+          {{ end }}
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+              readOnly: true
       restartPolicy: Always
   {{ if .Values.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
-        name: {{ .Release.Name }}-dev-data
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 8Gi
-        #storageClassName:
+  - metadata:
+      name: {{ .Release.Name }}-core-data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 8Gi
+      #storageClassName:
   {{ end }}
+
 ...

--- a/charts/odpi-egeria-lab/templates/egeria-factory.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-factory.yaml
@@ -9,61 +9,88 @@ metadata:
     helm.sh/chart: {{ include "myapp.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/component: factory
-  name: {{ include "myapp.fullname" . }}-factory
+    app.kubernetes.io/component: core
+  name: {{ .Release.Name }}-core
 
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - name: https
-      port: 9443
+    - port: 9443
       targetPort: 9443
       {{- if ( eq  .Values.service.type "NodePort" ) }}
-      nodePort: {{ .Values.service.nodeport.factory }}
+      nodePort: {{ .Values.service.nodeport.core }}
       {{- end }}
-    {{ if .Values.debug.egeriaJVM }}
+  {{ if .Values.debug.egeriaJVM }}
     - name: debug
       port: 5005
       targetPort: 5005
       {{- if ( eq  .Values.service.type "NodePort" ) }}
-      nodePort: {{ .Values.service.nodeport.debug.factory }}
+      nodePort: {{ .Values.service.nodeport.debug.core }}
       {{- end }}
   {{ end }}
   selector:
     app.kubernetes.io/name: {{ include "myapp.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: factory
+    app.kubernetes.io/component: core
 ...
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   creationTimestamp: null
-  name: {{ include "myapp.fullname" . }}-factory
+  name: {{ include "myapp.fullname" . }}-core
   labels:
     app.kubernetes.io/name: {{ include "myapp.name" . }}
     helm.sh/chart: {{ include "myapp.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/component: factory
+    app.kubernetes.io/component: core
 
 spec:
   replicas: 1
-  serviceName: {{ .Release.Name }}-factory
+  serviceName: {{ .Release.Name }}-core
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "myapp.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: factory
+      app.kubernetes.io/component: core
   template:
     metadata:
       creationTimestamp: null
       labels:
         app.kubernetes.io/name: {{ include "myapp.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/component: factory
+        app.kubernetes.io/component: core
     spec:
-      {{- include "egeria.security" . | nindent 6 }}
+    {{- include "egeria.security" . | nindent 6 }}
+    spec:
+      volumes:
+        - name: egeria-connector-volume
+          emptyDir: {}
+{{ if .Values.downloads }}
+      initContainers:
+        - name: init-connector
+          image: "{{ if (.Values.image.configure.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.configure.registry | default .Values.imageDefaults.registry }}/{{ end }}\
+                  {{ if (.Values.image.configure.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.configure.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
+                  {{ .Values.image.configure.name }}\
+                  :{{ .Values.image.configure.tag | default .Values.imageDefaults.tag }}"
+          imagePullPolicy: {{ .Values.image.configure.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Release.Name }}-env
+          command:
+            - "/bin/bash"
+            - "-c"
+            - >
+                cd /opt/egeria/connectors &&
+{{ range .Values.downloads }}
+                curl --location {{ .url | quote }} --output {{ .filename | quote }} &&
+{{ end }}
+                echo "Downloads complete."
+          volumeMounts:
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+{{ end }}
       containers:
         - name: egeria
           image: "{{ if (.Values.image.egeria.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.egeria.registry | default .Values.imageDefaults.registry }}/{{ end }}\
@@ -78,12 +105,14 @@ spec:
             {{ if .Values.debug.egeriaJVM }}
             - name: JAVA_DEBUG
               value:  "true"
-          {{ end }}
+            {{ end }}
+            - name: "LOADER_PATH"
+              value: "/deployments/server/lib,/opt/egeria/connectors"
           ports:
             - containerPort: 9443
-            {{ if .Values.debug.egeriaJVM }}
+          {{ if .Values.debug.egeriaJVM }}
             - containerPort: 5005
-            {{ end }}
+          {{ end }}
           readinessProbe:
             tcpSocket:
               port: 9443
@@ -91,16 +120,19 @@ spec:
             periodSeconds: 10
             failureThreshold: 6
           resources: {}
-          {{ if .Values.persistence.enabled }}
           volumeMounts:
+          {{ if .Values.persistence.enabled }}
             - mountPath: "/deployments/data"
-              name: {{ .Release.Name }}-factory-data
+              name: {{ .Release.Name }}-core-data
           {{ end }}
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+              readOnly: true
       restartPolicy: Always
   {{ if .Values.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
-      name: {{ .Release.Name }}-factory-data
+      name: {{ .Release.Name }}-core-data
     spec:
       accessModes:
         - ReadWriteOnce
@@ -109,4 +141,5 @@ spec:
           storage: 8Gi
       #storageClassName:
   {{ end }}
+
 ...

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -107,3 +107,9 @@ serviceAccount:
 
 persistence:
   enabled: false
+
+# Provide a list of URLs to all files (i.e. jars) that should be downloaded for connectivity, where
+# each item in the list is a dict pair of 'filename' and 'url', e.g.
+# - filename: my-connector-file.jar
+#   url: https://some-location/com?even=with&some-parameters=embedded&for-dynamic-download=true
+downloads:


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Support specification of additional connectors in remaining charts
 * odpi-egeria-lab
 
 Todo
  * egeria-base
  * add docs
  
  Follows same pattern established in egeria-cts. A configuration value is provided which specifies additional
Files which should be downloaded when the egeria container starts (implemented in an init container)

Usage:
 * set the ‘download’ value to true
 * set the ‘downloads’ value to a list of URLs to download from (file name/url pair)
 
 This will enable better support for demos that use additional connectors, such as Postgres, our Kafka connector, strimzi (in future), and allow continued use of graph once we remove that from the main egeria. It would also allow use of xtdb, though support of that should be escalated to first-class config