### PR TITLE
#130 reduce resource requirement spec for cts/pts

### DIFF
--- a/charts/egeria-cts/Chart.yaml
+++ b/charts/egeria-cts/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-cts
 description: Egeria Conformance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.7.0-prerelease.0
+version: 3.7.0-prerelease.1
 appVersion: 3.7
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-cts/values.yaml
+++ b/charts/egeria-cts/values.yaml
@@ -55,11 +55,11 @@ options:
 # --- Resource limits ---
 resources:
   requests:
+    memory: "4Gi"
+    cpu: "1000m"
+  limits:
     memory: "8Gi"
     cpu: "2000m"
-  limits:
-    memory: "16Gi"
-    cpu: "4000m"
 
 # --- Docker image sources ---
 # Defaults for the images (can be overridden here or individually, see comment below)

--- a/charts/egeria-pts/Chart.yaml
+++ b/charts/egeria-pts/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-pts
 description: Egeria Performance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.7.0-prerelease.0
+version: 3.7.0-prerelease.1
 appVersion: 3.7
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-pts/values.yaml
+++ b/charts/egeria-pts/values.yaml
@@ -61,11 +61,11 @@ options:
 # --- Resource limits ---
 resources:
   requests:
+    memory: "4Gi"
+    cpu: "1000m"
+  limits:
     memory: "8Gi"
     cpu: "2000m"
-  limits:
-    memory: "16Gi"
-    cpu: "4000m"
 
 # --- Docker image sources ---
 # Defaults for the images (can be overridden here or individually, see comment below)


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Reduces mem/cpu min requirement spec for CTS/PTS to 1 core / 4Gb ram (from 2 cores / 8 Gb ram). This is only a min 
spec to allow for scheduling, and can be overriden.

Using these values for testing release on openshift (for CTS at least)



