### PR TITLE
#138 add support for in-memory-repository to cts/pts charts

### DIFF
--- a/charts/egeria-cts/Chart.yaml
+++ b/charts/egeria-cts/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-cts
 description: Egeria Conformance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.7.0-prerelease.1
+version: 3.7.0-prerelease.2
 appVersion: 3.7
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
@@ -15,6 +15,8 @@ home: https://github.com/odpi/egeria
 maintainers:
   - name: Christopher Grote
     email: chris@thegrotes.net
+  - name: Nigel Jones
+    email: nigel.l.jones+git@gmail.com
 dependencies:
   - name: strimzi-kafka-operator
     version: 0.28.0

--- a/charts/egeria-cts/scripts/config-egeria.sh
+++ b/charts/egeria-cts/scripts/config-egeria.sh
@@ -53,6 +53,9 @@ if [ "${TUT_TYPE}" = "native" ]; then
   if [ "${CONNECTOR_PROVIDER}" = "org.odpi.openmetadata.adapters.repositoryservices.graphrepository.repositoryconnector.GraphOMRSRepositoryConnectorProvider" ]; then
     curl -f -k -w "\n   (%{http_code} - %{url_effective})\n" --silent -X POST \
       "${EGERIA_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${TUT_SERVER}/local-repository/mode/local-graph-repository" || exit $?
+  elif [ "${CONNECTOR_PROVIDER}" = "org.odpi.openmetadata.adapters.repositoryservices.inmemory.repositoryconnector.InMemoryOMRSRepositoryConnectorProvider" ]; then
+      curl -f -k -w "\n   (%{http_code} - %{url_effective})\n" --silent -X POST \
+        "${EGERIA_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${TUT_SERVER}/local-repository/mode/in-memory-repository" || exit $?
   else
     echo "-- Unknown native repository provider: ${CONNECTOR_PROVIDER} -- exiting."
     exit 1

--- a/charts/egeria-pts/Chart.yaml
+++ b/charts/egeria-pts/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-pts
 description: Egeria Performance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.7.0-prerelease.1
+version: 3.7.0-prerelease.2
 appVersion: 3.7
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
@@ -15,6 +15,8 @@ home: https://github.com/odpi/egeria
 maintainers:
   - name: Christopher Grote
     email: chris@thegrotes.net
+  - name: Nigel Jones
+    email: nigel.l.jones+git@gmail.com
 dependencies:
   - name: strimzi-kafka-operator
     version: 0.28.0

--- a/charts/egeria-pts/scripts/config-egeria.sh
+++ b/charts/egeria-pts/scripts/config-egeria.sh
@@ -51,11 +51,15 @@ curl -f -k -w "\n   (%{http_code} - %{url_effective})\n" --silent -X POST \
 if [ "${TUT_TYPE}" = "native" ]; then
   if [ "${CONNECTOR_PROVIDER}" = "org.odpi.openmetadata.adapters.repositoryservices.graphrepository.repositoryconnector.GraphOMRSRepositoryConnectorProvider" ]; then
     curl -f -k -w "\n   (%{http_code} - %{url_effective})\n" --silent -X POST \
-      "${TUT_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${TUT_SERVER}/local-repository/mode/local-graph-repository" || exit $?
+      "${EGERIA_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${TUT_SERVER}/local-repository/mode/local-graph-repository" || exit $?
+  elif [ "${CONNECTOR_PROVIDER}" = "org.odpi.openmetadata.adapters.repositoryservices.inmemory.repositoryconnector.InMemoryOMRSRepositoryConnectorProvider" ]; then
+      curl -f -k -w "\n   (%{http_code} - %{url_effective})\n" --silent -X POST \
+        "${EGERIA_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${TUT_SERVER}/local-repository/mode/in-memory-repository" || exit $?
   else
     echo "-- Unknown native repository provider: ${CONNECTOR_PROVIDER} -- exiting."
     exit 1
   fi
+
 elif [ "${TUT_TYPE}" = "plugin" ]; then
   curl -f -k -w "\n   (%{http_code} - %{url_effective})\n" --silent -X POST \
     --header "Content-Type: application/json" \


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Adds support for the in-memory-repository used for cts/pts

Note: Only cts tested as part of the release process.



