### PR TITLE
 add configurable delay between cts/pts & tut to improve reliability

### DIFF
--- a/charts/egeria-cts/Chart.yaml
+++ b/charts/egeria-cts/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-cts
 description: Egeria Conformance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.7.0-prerelease.4
+version: 3.7.0-prerelease.5
 appVersion: 3.7
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-cts/scripts/run-cts.sh
+++ b/charts/egeria-cts/scripts/run-cts.sh
@@ -18,8 +18,6 @@ else
   echo ${response}
 fi
 
-echo -e `\n > Pausing for ${START_DELAY} seconds for the CTS server to stabilize...`
-
 sleep ${START_DELAY}
 
 # Wait for CTS to stabilize

--- a/charts/egeria-cts/scripts/run-cts.sh
+++ b/charts/egeria-cts/scripts/run-cts.sh
@@ -11,13 +11,18 @@ response=$(curl -f -k --silent -X POST \
   "${EGERIA_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_SERVER}/instance") || exit $?
 
 if [ "200" != "$(echo ${response} | jq '.relatedHTTPCode')" ]; then
-  echo "Unable to start the PTS server:"
+  echo "Unable to start the CTS server:"
   echo ${response}
   exit 2
 else
   echo ${response}
 fi
 
+echo -e `\n > Pausing for ${START_DELAY} seconds for the CTS server to stabilize...`
+
+sleep ${START_DELAY}
+
+# Wait for CTS to stabilize
 echo -e '\n > Starting the technology under test:\n'
 
 response=$(curl -f -k --silent -X POST --max-time 900 \

--- a/charts/egeria-cts/templates/env.yaml
+++ b/charts/egeria-cts/templates/env.yaml
@@ -24,6 +24,7 @@ data:
   EGERIA_COHORT: {{ .Values.egeria.cohort }}
   KAFKA_ENDPOINT: {{ .Release.Name }}-strimzi-kafka-bootstrap:9092
   EGERIA_SERVER: {{ .Values.egeria.serverName }}
+  START_DELAY: "{{ .Values.egeria.delay }}"
 
   # CTS-specific configuration
   CTS_FACTOR: "{{ .Values.records }}"

--- a/charts/egeria-cts/values.yaml
+++ b/charts/egeria-cts/values.yaml
@@ -7,6 +7,8 @@ egeria:
   user: admin
   cohort: cts
   serverName: cts
+  # Adds a delay between the CTS server being started, and starting the TUT server
+  delay: 10
 
 # --- CTS configuration ---
 # "Scale factor" for the CTS (sets a limit on the overall number of records, search results, etc)

--- a/charts/egeria-pts/Chart.yaml
+++ b/charts/egeria-pts/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-pts
 description: Egeria Performance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.7.0-prerelease.3
+version: 3.7.0-prerelease.4
 appVersion: 3.7
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-pts/scripts/run-pts.sh
+++ b/charts/egeria-pts/scripts/run-pts.sh
@@ -18,6 +18,10 @@ else
   echo ${response}
 fi
 
+echo -e `\n > Pausing for ${START_DELAY} seconds for the PTS server to stabilize...`
+
+sleep ${START_DELAY}
+
 echo -e '\n > Starting the technology under test:\n'
 
 response=$(curl -f -k --silent -X POST --max-time 900 \

--- a/charts/egeria-pts/scripts/run-pts.sh
+++ b/charts/egeria-pts/scripts/run-pts.sh
@@ -18,8 +18,6 @@ else
   echo ${response}
 fi
 
-echo -e `\n > Pausing for ${START_DELAY} seconds for the PTS server to stabilize...`
-
 sleep ${START_DELAY}
 
 echo -e '\n > Starting the technology under test:\n'

--- a/charts/egeria-pts/templates/env.yaml
+++ b/charts/egeria-pts/templates/env.yaml
@@ -25,6 +25,7 @@ data:
   EGERIA_COHORT: {{ .Values.egeria.cohort }}
   KAFKA_ENDPOINT: {{ .Release.Name }}-strimzi-kafka-bootstrap:9092
   PTS_SERVER: {{ .Values.egeria.serverName }}
+  START_DELAY: "{{ .Values.egeria.delay }}"
 
   # PTS-specific configuration
   INSTANCES_PER_TYPE: "{{ .Values.volumeParameters.instancesPerType }}"

--- a/charts/egeria-pts/values.yaml
+++ b/charts/egeria-pts/values.yaml
@@ -7,6 +7,8 @@ egeria:
   user: admin
   cohort: pts
   serverName: pts
+  # Adds a delay between the PTS server being started, and starting the TUT server
+  delay: 10
 
 # --- PTS configuration ---
 # These control the volumetrics of the PTS


### PR DESCRIPTION


Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Adds configurable delay (default 10s) between launch of cts/pts & tut

Value that can be set is 'egeria.delay'



