### PR TITLE
odpi/egeria#6435 First prerelease version for the 3.8 release

### DIFF
--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -4,8 +4,8 @@
 name: egeria-base
 description: Egeria simple deployment (platform, react UI)
 apiVersion: v2
-version: 3.7.1-prerelease.2
-appVersion: 3.7
+version: 3.8.0-prerelease.0
+appVersion: 3.8
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
   - odpi, egeria, base, simple

--- a/charts/egeria-base/values.yaml
+++ b/charts/egeria-base/values.yaml
@@ -6,7 +6,7 @@
 egeria:
   # Set to INFO, WARNING, DEBUG if needed
   logging: 
-  version: "3.7"
+  version: "3.8"
   repositoryType: "local-graph-repository"
   debug: false
   persistence: true

--- a/charts/egeria-cts/Chart.yaml
+++ b/charts/egeria-cts/Chart.yaml
@@ -4,8 +4,8 @@
 name: egeria-cts
 description: Egeria Conformance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.7.0
-appVersion: 3.7
+version: 3.8.0-prerelease.0
+appVersion: 3.8
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
   - odpi, egeria, cts

--- a/charts/egeria-cts/values.yaml
+++ b/charts/egeria-cts/values.yaml
@@ -68,7 +68,7 @@ resources:
 imageDefaults:
   registry: quay.io
   namespace: odpi
-  tag: 3.7
+  tag: 3.8
   pullPolicy: IfNotPresent
 
 # The following section defines all DOCKER images being used by this chart. Normally they should be left as is,

--- a/charts/egeria-pts/Chart.yaml
+++ b/charts/egeria-pts/Chart.yaml
@@ -4,8 +4,8 @@
 name: egeria-pts
 description: Egeria Performance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.7.0
-appVersion: 3.7
+version: 3.8.0-prerelease.0
+appVersion: 3.8
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
   - odpi, egeria, pts

--- a/charts/egeria-pts/values.yaml
+++ b/charts/egeria-pts/values.yaml
@@ -74,7 +74,7 @@ resources:
 imageDefaults:
   registry: quay.io
   namespace: odpi
-  tag: 3.7
+  tag: 3.8
   pullPolicy: IfNotPresent
 
 ...

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,8 +4,8 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v1
-version: 3.7.1-prerelease.1
-appVersion: 3.7
+version: 3.8.0-prerelease.0
+appVersion: 3.8
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
   - odpi, egeria, lab, jupyter, notebook

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -31,7 +31,7 @@ service:
 egeria:
   #logging: OFF
   development: true
-  version: "3.7"
+  version: "3.8"
   #repositoryType: "local-graph-repository"
   repositoryType: "in-memory-repository"
   # See https://github.com/odpi/egeria-charts/issues/56 for status of the Egeria UI (polymer) in this environment


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

First pre-release for egeria 3.8

Note:
 - React UI is at 3.8.0-rc.0 (@davidradl I'll start tests with core egeria now, let's update this version when you have a new release)
 - Polymer UI is at 3.2.0 (@sarbull @lpalashevski )