### PR TITLE
3.9.0 fixes - jupyter & security context

### DIFF
--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-base
 description: Egeria simple deployment (platform, react UI)
 apiVersion: v2
-version: 3.9.0
+version: 3.9.1
 appVersion: 3.9
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-base/templates/kafka-cluster.yaml
+++ b/charts/egeria-base/templates/kafka-cluster.yaml
@@ -34,12 +34,24 @@ spec:
           type: persistent-claim
           size: 5Gi
           deleteClaim: true
+    template:
+      pod:
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          fsGroup: 1001
   zookeeper:
     replicas: 1
     storage:
       type: persistent-claim
       size: 1Gi
       deleteClaim: true
+    template:
+      pod:
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          fsGroup: 1001
   entityOperator:
     topicOperator:
       reconciliationIntervalSeconds: 20

--- a/charts/egeria-cts/Chart.yaml
+++ b/charts/egeria-cts/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-cts
 description: Egeria Conformance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.9.0
+version: 3.9.1
 appVersion: 3.9
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-cts/templates/kafka-cluster.yaml
+++ b/charts/egeria-cts/templates/kafka-cluster.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   kafka:
     version: 3.0.0
-    replicas: 3
+    replicas: 1
     listeners:
       - name: plain
         port: 9092
@@ -34,12 +34,24 @@ spec:
           type: persistent-claim
           size: 5Gi
           deleteClaim: true
+    template:
+      pod:
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          fsGroup: 1001
   zookeeper:
     replicas: 1
     storage:
       type: persistent-claim
       size: 1Gi
       deleteClaim: true
+    template:
+      pod:
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          fsGroup: 1001
   entityOperator:
     topicOperator:
       reconciliationIntervalSeconds: 20

--- a/charts/egeria-pts/Chart.yaml
+++ b/charts/egeria-pts/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-pts
 description: Egeria Performance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.9.0
+version: 3.9.1
 appVersion: 3.9
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-pts/templates/kafka-cluster.yaml
+++ b/charts/egeria-pts/templates/kafka-cluster.yaml
@@ -34,12 +34,24 @@ spec:
           type: persistent-claim
           size: 5Gi
           deleteClaim: true
+    template:
+      pod:
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          fsGroup: 1001
   zookeeper:
     replicas: 1
     storage:
       type: persistent-claim
       size: 1Gi
       deleteClaim: true
+    template:
+      pod:
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          fsGroup: 1001
   entityOperator:
     topicOperator:
       reconciliationIntervalSeconds: 20

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v1
-version: 3.9.0
+version: 3.9.1
 appVersion: 3.9
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
+++ b/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
@@ -34,12 +34,24 @@ spec:
           type: persistent-claim
           size: 5Gi
           deleteClaim: true
+    template:
+      pod:
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          fsGroup: 1001
   zookeeper:
     replicas: 1
     storage:
       type: persistent-claim
       size: 1Gi
       deleteClaim: true
+    template:
+      pod:
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          fsGroup: 1001
   entityOperator:
     topicOperator:
       reconciliationIntervalSeconds: 20

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -69,7 +69,6 @@ image:
     name: egeria-configure
   jupyter:
     name: jupyter
-    tag: "latest"
   uistatic:
     name: egeria-ui
     tag: "3.2.0"


### PR DESCRIPTION
* Corrects version of jupyter container image (this is an egeria customized version) to align with egeria release by default
* Adds securityContext for kafka/zookeeper pods created by Strimzi to ensure works ok in clean OpenShift 4.10 install
* Bumps version