### PR TITLE
Set security context for egeria containers

### DIFF
--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-base
 description: Egeria simple deployment (platform, react UI)
 apiVersion: v2
-version: 3.9.1
+version: 3.9.2
 appVersion: 3.9
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-base/templates/platform.yaml
+++ b/charts/egeria-base/templates/platform.yaml
@@ -122,6 +122,10 @@ spec:
         - name: extlib
           configMap:
             name: {{ .Release.Name }}-extlib
+      securityContext:
+        runAsUser: 185
+        runAsGroup: 185
+        fsGroup: 185
   {{ if .Values.egeria.persistence }}
   volumeClaimTemplates:
   - metadata:

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v1
-version: 3.9.1
+version: 3.9.2
 appVersion: 3.9
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/templates/_helpers.tpl
+++ b/charts/odpi-egeria-lab/templates/_helpers.tpl
@@ -47,3 +47,10 @@ Create the name of the service account to use
 {{- define "egeria.security" -}}
 serviceAccountName: {{ template "mychart.serviceAccountName" . }}
 {{- end }}
+
+{{- define "egeria.platformscc" -}}
+securityContext:
+  runAsUser: 185
+  runAsGroup: 185
+  fsGroup: 185
+{{- end }}

--- a/charts/odpi-egeria-lab/templates/egeria-core.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-core.yaml
@@ -96,6 +96,7 @@ spec:
               name: {{ .Release.Name }}-core-data
           {{ end }}
       restartPolicy: Always
+      {{- include "egeria.platformscc" . | nindent 6 }}
   {{ if .Values.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:

--- a/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
@@ -96,6 +96,7 @@ spec:
               name: {{ .Release.Name }}-datalake-data
           {{ end }}
       restartPolicy: Always
+      {{- include "egeria.platformscc" . | nindent 6 }}
   {{ if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/odpi-egeria-lab/templates/egeria-dev.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-dev.yaml
@@ -97,6 +97,7 @@ spec:
               name: {{ .Release.Name }}-dev-data
          {{ end }}
       restartPolicy: Always
+      {{- include "egeria.platformscc" . | nindent 6 }}
   {{ if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/odpi-egeria-lab/templates/egeria-factory.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-factory.yaml
@@ -97,6 +97,7 @@ spec:
               name: {{ .Release.Name }}-factory-data
           {{ end }}
       restartPolicy: Always
+      {{- include "egeria.platformscc" . | nindent 6 }}
   {{ if .Values.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:


### PR DESCRIPTION
Fixes: #158

- Adds security context for egeria platform containers. This ensures any volumes are mounted with the correct permissions, and are therefore writeable.
- Bumps version to 3.9.2 for incremental release

Tested in:
 - Openshift 4.10
 - Rancher desktop 1.4.1 / k8s 1.24.1