### PR TITLE
#117 make strimzi install optional (for multiple per cluster)

### DIFF
--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -19,3 +19,4 @@ dependencies:
   - name: strimzi-kafka-operator
     version: 0.29.0
     repository: https://strimzi.io/charts/
+    condition: strimzi.enabled

--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-base
 description: Egeria simple deployment (platform, react UI)
 apiVersion: v2
-version: 3.9.2
+version: 3.9.3
 appVersion: 3.9
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-base/values.yaml
+++ b/charts/egeria-base/values.yaml
@@ -101,3 +101,20 @@ image:
     tag: "3.8.0"
   configure:
     name: egeria-configure
+
+# Normally we install the strimzi operator as part of the Chart. However this requires admin permissions, and
+# will create cluster-scoped resources. Set to false to skip this when in a restricted environment, or needing multiple
+# installs of egeria charts in the same cluster. Requires the strimzi operator to be
+# installed on the cluster by an admin, or a prior install
+strimzi:
+  enabled: true
+
+# If you allow (as is default) this chart to install the strimzi operator, this setting will
+# then allow it to work across all namespaces - so for example it will work if installing another
+# version of the chart, as long as that install has strimzi.enabled=false.
+# However it is better to install strimzi manually for these more complex environments, so the default is false
+#
+# helm repo add strimzi https://strimzi.io/charts/
+# helm repo update && helm install strimzi strimzi/strimzi-kafka-operator --set watchAnyNamespace=true
+strimzi-kafka-operator:
+  watchAnyNamespace: false

--- a/charts/egeria-cts/Chart.yaml
+++ b/charts/egeria-cts/Chart.yaml
@@ -21,4 +21,6 @@ dependencies:
   - name: strimzi-kafka-operator
     version: 0.29.0
     repository: https://strimzi.io/charts/
+    condition: strimzi.enabled
+
 

--- a/charts/egeria-cts/Chart.yaml
+++ b/charts/egeria-cts/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-cts
 description: Egeria Conformance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.9.1
+version: 3.9.2
 appVersion: 3.9
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-cts/values.yaml
+++ b/charts/egeria-cts/values.yaml
@@ -81,3 +81,10 @@ image:
     name: egeria
   configure:
     name: egeria-configure
+
+# Normally we install the strimzi operator as part of the Chart. However this requires admin permissions, and
+# will create cluster-scoped resources. Set to false to skip this when in a restricted environment, or needing multiple
+# installs of egeria charts in the same cluster. Requires the strimzi operator to be
+# installed on the cluster by an admin, or a prior install
+strimzi:
+  enabled: true

--- a/charts/egeria-pts/Chart.yaml
+++ b/charts/egeria-pts/Chart.yaml
@@ -21,4 +21,5 @@ dependencies:
   - name: strimzi-kafka-operator
     version: 0.29.0
     repository: https://strimzi.io/charts/
+    condition: strimzi.enabled
 

--- a/charts/egeria-pts/Chart.yaml
+++ b/charts/egeria-pts/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-pts
 description: Egeria Performance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.9.1
+version: 3.9.2
 appVersion: 3.9
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-pts/values.yaml
+++ b/charts/egeria-pts/values.yaml
@@ -77,4 +77,10 @@ imageDefaults:
   tag: 3.9
   pullPolicy: IfNotPresent
 
-...
+# Normally we install the strimzi operator as part of the Chart. However this requires admin permissions, and
+# will create cluster-scoped resources. Set to false to skip this when in a restricted environment, or needing multiple
+# installs of egeria charts in the same cluster. Requires the strimzi operator to be
+# installed on the cluster by an admin, or a prior install
+strimzi:
+  enabled: true
+

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -21,3 +21,4 @@ dependencies:
   - name: strimzi-kafka-operator
     version: 0.29.0
     repository: https://strimzi.io/charts/
+    condition: strimzi.enabled

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v1
-version: 3.9.2
+version: 3.9.3
 appVersion: 3.9
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -106,3 +106,10 @@ serviceAccount:
 
 persistence:
   enabled: false
+
+# Normally we install the strimzi operator as part of the Chart. However this requires admin permissions, and
+# will create cluster-scoped resources. Set to false to skip this when in a restricted environment, or needing multiple
+# installs of egeria charts in the same cluster. Requires the strimzi operator to be
+# installed on the cluster by an admin, or a prior install
+strimzi:
+  enabled: true


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

This change allows strimzi to *optionally* be installed alongside any of our helm charts

This is needed when either
* The user installing does not have admin rights to the cluster - for example they are a regular user given access to a namespace just to deploy apps
* You want to install multiple versions of the egeria helm charts - for example when testing/debugging, or running a long-running cts whilst continuing with dev work!

Strimzi installs some cluster-scoped resources which a) are cluster-scoped ie global, and so cannot clash with namespace local and b) require higher permissions - again, due to their scope.

In both cases the strimzi operator should be installed first, manually. This can be done by following the [official documentation](https://strimzi.io/blog/2018/11/01/using-helm/) or by installing the operator from the operator catalog. If you do not have cluster permissions you will need to ask a cluster administrator to do this before you can experiment with egeria

To skip the install of strimzi you can add an option ie:
```
helm install base egeria/egeria-base --set strimzi.enabled=false 
```

We will still deploy the custom resource to create a kafka cluster, but this will only work if strimzi is installed on the cluster.

The default remains to install strimzi by default.