### PR TITLE
#156 set securityContext to {}

### DIFF
--- a/charts/egeria-base/templates/kafka-cluster.yaml
+++ b/charts/egeria-base/templates/kafka-cluster.yaml
@@ -37,9 +37,7 @@ spec:
     template:
       pod:
         securityContext:
-          runAsUser: 1001
-          runAsGroup: 1001
-          fsGroup: 1001
+          {  }
   zookeeper:
     replicas: 1
     storage:
@@ -49,9 +47,7 @@ spec:
     template:
       pod:
         securityContext:
-          runAsUser: 1001
-          runAsGroup: 1001
-          fsGroup: 1001
+          { }
   entityOperator:
     topicOperator:
       reconciliationIntervalSeconds: 20

--- a/charts/egeria-base/templates/platform.yaml
+++ b/charts/egeria-base/templates/platform.yaml
@@ -123,9 +123,7 @@ spec:
           configMap:
             name: {{ .Release.Name }}-extlib
       securityContext:
-        runAsUser: 185
-        runAsGroup: 185
-        fsGroup: 185
+        {  }
   {{ if .Values.egeria.persistence }}
   volumeClaimTemplates:
   - metadata:

--- a/charts/egeria-cts/templates/kafka-cluster.yaml
+++ b/charts/egeria-cts/templates/kafka-cluster.yaml
@@ -37,9 +37,7 @@ spec:
     template:
       pod:
         securityContext:
-          runAsUser: 1001
-          runAsGroup: 1001
-          fsGroup: 1001
+          { }
   zookeeper:
     replicas: 1
     storage:
@@ -49,9 +47,7 @@ spec:
     template:
       pod:
         securityContext:
-          runAsUser: 1001
-          runAsGroup: 1001
-          fsGroup: 1001
+          { }
   entityOperator:
     topicOperator:
       reconciliationIntervalSeconds: 20

--- a/charts/egeria-pts/templates/kafka-cluster.yaml
+++ b/charts/egeria-pts/templates/kafka-cluster.yaml
@@ -37,9 +37,7 @@ spec:
     template:
       pod:
         securityContext:
-          runAsUser: 1001
-          runAsGroup: 1001
-          fsGroup: 1001
+          { }
   zookeeper:
     replicas: 1
     storage:
@@ -49,9 +47,7 @@ spec:
     template:
       pod:
         securityContext:
-          runAsUser: 1001
-          runAsGroup: 1001
-          fsGroup: 1001
+          { }
   entityOperator:
     topicOperator:
       reconciliationIntervalSeconds: 20

--- a/charts/odpi-egeria-lab/templates/_helpers.tpl
+++ b/charts/odpi-egeria-lab/templates/_helpers.tpl
@@ -50,7 +50,5 @@ serviceAccountName: {{ template "mychart.serviceAccountName" . }}
 
 {{- define "egeria.platformscc" -}}
 securityContext:
-  runAsUser: 185
-  runAsGroup: 185
-  fsGroup: 185
+  { }
 {{- end }}

--- a/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
+++ b/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
@@ -37,9 +37,7 @@ spec:
     template:
       pod:
         securityContext:
-          runAsUser: 1001
-          runAsGroup: 1001
-          fsGroup: 1001
+          {  }
   zookeeper:
     replicas: 1
     storage:
@@ -49,9 +47,7 @@ spec:
     template:
       pod:
         securityContext:
-          runAsUser: 1001
-          runAsGroup: 1001
-          fsGroup: 1001
+          { }
   entityOperator:
     topicOperator:
       reconciliationIntervalSeconds: 20


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Resets securityContext to {}

Fixes #156 properly, but see egeria-docs for update to document that the 'default' namespace should not be used