### PR TITLE
odpi/egeria#6554 quote version due to yaml parsing stripping trailing…

### DIFF
--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -4,8 +4,8 @@
 name: egeria-base
 description: Egeria simple deployment (platform, react UI)
 apiVersion: v2
-version: 3.10.0-prerelease.0
-appVersion: 3.10
+version: 3.10.0-prerelease.1
+appVersion: "3.10"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
   - odpi, egeria, base, simple

--- a/charts/egeria-cts/Chart.yaml
+++ b/charts/egeria-cts/Chart.yaml
@@ -4,8 +4,8 @@
 name: egeria-cts
 description: Egeria Conformance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.10.0-prerelease.0
-appVersion: 3.10
+version: 3.10.0-prerelease.1
+appVersion: "3.10"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
   - odpi, egeria, cts

--- a/charts/egeria-pts/Chart.yaml
+++ b/charts/egeria-pts/Chart.yaml
@@ -4,8 +4,8 @@
 name: egeria-pts
 description: Egeria Performance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.10.0-prerelease.0
-appVersion: 3.10
+version: 3.10.0-prerelease.1
+appVersion: "3.10"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
   - odpi, egeria, pts

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -3,9 +3,9 @@
 ---
 name: odpi-egeria-lab
 description: Egeria lab environment
-apiVersion: v1
-version: 3.10.0-prerelease.0
-appVersion: 3.10
+apiVersion: v2
+version: 3.10.0-prerelease.1
+appVersion: "3.10"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
   - odpi, egeria, lab, jupyter, notebook


### PR DESCRIPTION
… 0 & set api to v2

Fixes needed from testing
* APP version is showing as 3.1 not 3.10 as the yaml parser is stripping the trailing 0 when appVersion string is not quoted (it does not do this for chart version!)
* API version for odpi-egeria-lab was set to v1. This resulted in a minor lint warning about dependencies
* Versions updated

Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>