### PR TITLE
#3 Allow additional connectors to be downloaded

### DIFF
--- a/charts/egeria-base/templates/platform.yaml
+++ b/charts/egeria-base/templates/platform.yaml
@@ -37,7 +37,6 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  creationTimestamp: null
   name: {{ include "myapp.name" . }}-platform
   labels:
     app.kubernetes.io/name: {{ include "myapp.name" . }}
@@ -56,7 +55,6 @@ spec:
       app.kubernetes.io/component: platform
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app.kubernetes.io/name: {{ include "myapp.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/egeria-base/templates/presentation.yaml
+++ b/charts/egeria-base/templates/presentation.yaml
@@ -29,7 +29,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   name: {{ include "myapp.name" . }}-presentation
   labels:
     app.kubernetes.io/name: {{ include "myapp.name" . }}
@@ -48,7 +47,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app.kubernetes.io/name: {{ include "myapp.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -96,5 +94,4 @@ spec:
                 name: {{ .Release.Name }}-env
       restartPolicy: Always
 
-status: {}
 ...

--- a/charts/egeria-cts/templates/platform.yaml
+++ b/charts/egeria-cts/templates/platform.yaml
@@ -108,5 +108,4 @@ spec:
               name: egeria-connector-volume
               readOnly: true
 
-status: {}
 ...

--- a/charts/egeria-pts/templates/pts.yaml
+++ b/charts/egeria-pts/templates/pts.yaml
@@ -74,5 +74,4 @@ spec:
               memory: "{{ .Values.resources.limits.memory }}"
               cpu: "{{ .Values.resources.limits.cpu }}"
 
-status: {}
 ...

--- a/charts/egeria-pts/templates/tut.yaml
+++ b/charts/egeria-pts/templates/tut.yaml
@@ -108,5 +108,4 @@ spec:
               name: egeria-connector-volume
               readOnly: true
 
-status: {}
 ...

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v2
-version: 3.11.0-prerelease.1
+version: 3.11.0-prerelease.2
 appVersion: "3.10"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/templates/egeria-core.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-core.yaml
@@ -37,7 +37,6 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  creationTimestamp: null
   name: {{ include "myapp.fullname" . }}-core
   labels:
     app.kubernetes.io/name: {{ include "myapp.name" . }}
@@ -56,13 +55,36 @@ spec:
       app.kubernetes.io/component: core
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app.kubernetes.io/name: {{ include "myapp.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: core
     spec:
     {{- include "egeria.security" . | nindent 6 }}
+      volumes:
+        - name: egeria-connector-volume
+          emptyDir: {}
+{{ if .Values.downloads }}
+      initContainers:
+        - name: init-connector
+          image: "{{ if (.Values.image.configure.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.configure.registry | default .Values.imageDefaults.registry }}/{{ end }}\
+                  {{ if (.Values.image.configure.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.configure.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
+                  {{ .Values.image.configure.name }}\
+                  :{{ .Values.image.configure.tag | default .Values.imageDefaults.tag }}"
+          imagePullPolicy: {{ .Values.image.configure.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          command:
+            - "/bin/bash"
+            - "-c"
+            - >
+                cd /opt/egeria/connectors &&
+{{ range .Values.downloads }}
+                curl --location {{ .url | quote }} --output {{ .filename | quote }} &&
+{{ end }}
+                echo "Downloads complete."
+          volumeMounts:
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+{{ end }}
       containers:
         - name: egeria
           image: "{{ if (.Values.image.egeria.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.egeria.registry | default .Values.imageDefaults.registry }}/{{ end }}\
@@ -78,6 +100,8 @@ spec:
             - name: JAVA_DEBUG
               value:  "true"
             {{ end }}
+            - name: "LOADER_PATH"
+              value: "/deployments/server/lib,/opt/egeria/connectors"
           ports:
             - containerPort: 9443
           {{ if .Values.debug.egeriaJVM }}
@@ -90,11 +114,14 @@ spec:
             periodSeconds: 10
             failureThreshold: 6
           resources: {}
-          {{ if .Values.persistence.enabled }}
           volumeMounts:
+          {{ if .Values.persistence.enabled }}
             - mountPath: "/deployments/data"
               name: {{ .Release.Name }}-core-data
           {{ end }}
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+              readOnly: true
       restartPolicy: Always
       {{- include "egeria.platformscc" . | nindent 6 }}
   {{ if .Values.persistence.enabled }}

--- a/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
@@ -37,7 +37,6 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  creationTimestamp: null
   name: {{ include "myapp.fullname" . }}-datalake
   labels:
     app.kubernetes.io/name: {{ include "myapp.name" . }}
@@ -56,13 +55,36 @@ spec:
       app.kubernetes.io/component: datalake
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app.kubernetes.io/name: {{ include "myapp.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: datalake
     spec:
-      {{- include "egeria.security" . | nindent 6 }}
+    {{- include "egeria.security" . | nindent 6 }}
+      volumes:
+        - name: egeria-connector-volume
+          emptyDir: {}
+{{ if .Values.downloads }}
+      initContainers:
+        - name: init-connector
+          image: "{{ if (.Values.image.configure.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.configure.registry | default .Values.imageDefaults.registry }}/{{ end }}\
+                  {{ if (.Values.image.configure.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.configure.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
+                  {{ .Values.image.configure.name }}\
+                  :{{ .Values.image.configure.tag | default .Values.imageDefaults.tag }}"
+          imagePullPolicy: {{ .Values.image.configure.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          command:
+            - "/bin/bash"
+            - "-c"
+            - >
+                cd /opt/egeria/connectors &&
+{{ range .Values.downloads }}
+                curl --location {{ .url | quote }} --output {{ .filename | quote }} &&
+{{ end }}
+                echo "Downloads complete."
+          volumeMounts:
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+{{ end }}
       containers:
         - name: egeria
           image: "{{ if (.Values.image.egeria.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.egeria.registry | default .Values.imageDefaults.registry }}/{{ end }}\
@@ -78,6 +100,8 @@ spec:
             - name: JAVA_DEBUG
               value:  "true"
             {{ end }}
+            - name: "LOADER_PATH"
+              value: "/deployments/server/lib,/opt/egeria/connectors"
           ports:
             - containerPort: 9443
           {{ if .Values.debug.egeriaJVM }}
@@ -90,11 +114,14 @@ spec:
             periodSeconds: 10
             failureThreshold: 6
           resources: {}
-          {{ if .Values.persistence.enabled }}
           volumeMounts:
+          {{ if .Values.persistence.enabled }}
             - mountPath: "/deployments/data"
               name: {{ .Release.Name }}-datalake-data
           {{ end }}
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+              readOnly: true
       restartPolicy: Always
       {{- include "egeria.platformscc" . | nindent 6 }}
   {{ if .Values.persistence.enabled }}

--- a/charts/odpi-egeria-lab/templates/egeria-dev.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-dev.yaml
@@ -38,7 +38,6 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  creationTimestamp: null
   name: {{ include "myapp.fullname" . }}-dev
   labels:
     app.kubernetes.io/name: {{ include "myapp.name" . }}
@@ -57,13 +56,37 @@ spec:
       app.kubernetes.io/component: dev
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app.kubernetes.io/name: {{ include "myapp.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: dev
     spec:
-      {{- include "egeria.security" . | nindent 6 }}
+    {{- include "egeria.security" . | nindent 6 }}
+      volumes:
+        - name: egeria-connector-volume
+          emptyDir: {}
+{{ if .Values.downloads }}
+      initContainers:
+        - name: init-connector
+          image: "{{ if (.Values.image.configure.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.configure.registry | default .Values.imageDefaults.registry }}/{{ end }}\
+                  {{ if (.Values.image.configure.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.configure.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
+                  {{ .Values.image.configure.name }}\
+                  :{{ .Values.image.configure.tag | default .Values.imageDefaults.tag }}"
+          imagePullPolicy: {{ .Values.image.configure.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+
+          command:
+            - "/bin/bash"
+            - "-c"
+            - >
+                cd /opt/egeria/connectors &&
+{{ range .Values.downloads }}
+                curl --location {{ .url | quote }} --output {{ .filename | quote }} &&
+{{ end }}
+                echo "Downloads complete."
+          volumeMounts:
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+{{ end }}
       containers:
         - name: egeria
           image: "{{ if (.Values.image.egeria.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.egeria.registry | default .Values.imageDefaults.registry }}/{{ end }}\
@@ -79,6 +102,8 @@ spec:
              - name: JAVA_DEBUG
                value:  "true"
             {{ end }}
+            - name: "LOADER_PATH"
+              value: "/deployments/server/lib,/opt/egeria/connectors"
           ports:
             - containerPort: 9443
             {{ if .Values.debug.egeriaJVM }}
@@ -91,11 +116,14 @@ spec:
             periodSeconds: 10
             failureThreshold: 6
           resources: {}
-          {{ if .Values.persistence.enabled }}
           volumeMounts:
+          {{ if .Values.persistence.enabled }}
             - mountPath: "/deployments/data"
               name: {{ .Release.Name }}-dev-data
-         {{ end }}
+          {{ end }}
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+              readOnly: true
       restartPolicy: Always
       {{- include "egeria.platformscc" . | nindent 6 }}
   {{ if .Values.persistence.enabled }}

--- a/charts/odpi-egeria-lab/templates/egeria-factory.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-factory.yaml
@@ -38,7 +38,6 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  creationTimestamp: null
   name: {{ include "myapp.fullname" . }}-factory
   labels:
     app.kubernetes.io/name: {{ include "myapp.name" . }}
@@ -57,13 +56,36 @@ spec:
       app.kubernetes.io/component: factory
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app.kubernetes.io/name: {{ include "myapp.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: factory
     spec:
-      {{- include "egeria.security" . | nindent 6 }}
+    {{- include "egeria.security" . | nindent 6 }}
+      volumes:
+        - name: egeria-connector-volume
+          emptyDir: {}
+{{ if .Values.downloads }}
+      initContainers:
+        - name: init-connector
+          image: "{{ if (.Values.image.configure.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.configure.registry | default .Values.imageDefaults.registry }}/{{ end }}\
+                  {{ if (.Values.image.configure.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.configure.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
+                  {{ .Values.image.configure.name }}\
+                  :{{ .Values.image.configure.tag | default .Values.imageDefaults.tag }}"
+          imagePullPolicy: {{ .Values.image.configure.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          command:
+            - "/bin/bash"
+            - "-c"
+            - >
+                cd /opt/egeria/connectors &&
+{{ range .Values.downloads }}
+                curl --location {{ .url | quote }} --output {{ .filename | quote }} &&
+{{ end }}
+                echo "Downloads complete."
+          volumeMounts:
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+{{ end }}
       containers:
         - name: egeria
           image: "{{ if (.Values.image.egeria.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.egeria.registry | default .Values.imageDefaults.registry }}/{{ end }}\
@@ -78,7 +100,9 @@ spec:
             {{ if .Values.debug.egeriaJVM }}
             - name: JAVA_DEBUG
               value:  "true"
-          {{ end }}
+            {{ end }}
+            - name: "LOADER_PATH"
+              value: "/deployments/server/lib,/opt/egeria/connectors"
           ports:
             - containerPort: 9443
             {{ if .Values.debug.egeriaJVM }}
@@ -91,11 +115,14 @@ spec:
             periodSeconds: 10
             failureThreshold: 6
           resources: {}
-          {{ if .Values.persistence.enabled }}
           volumeMounts:
+          {{ if .Values.persistence.enabled }}
             - mountPath: "/deployments/data"
               name: {{ .Release.Name }}-factory-data
           {{ end }}
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+              readOnly: true
       restartPolicy: Always
       {{- include "egeria.platformscc" . | nindent 6 }}
   {{ if .Values.persistence.enabled }}

--- a/charts/odpi-egeria-lab/templates/egeria-nginx.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-nginx.yaml
@@ -69,7 +69,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   name: {{ include "myapp.fullname" . }}-nginx
   labels:
     app.kubernetes.io/name: {{ include "myapp.name" . }}
@@ -88,7 +87,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app.kubernetes.io/name: {{ include "myapp.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -156,7 +154,6 @@ spec:
             items:
               - key: pass.txt
                 path: pass.txt
-status: {}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/odpi-egeria-lab/templates/egeria-presentation.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-presentation.yaml
@@ -29,7 +29,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   name: {{ include "myapp.fullname" . }}-presentation
   labels:
     app.kubernetes.io/name: {{ include "myapp.name" . }}
@@ -48,7 +47,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app.kubernetes.io/name: {{ include "myapp.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -80,5 +78,4 @@ spec:
               value: "false"
       restartPolicy: Always
 
-status: {}
 ...

--- a/charts/odpi-egeria-lab/templates/egeria-ui.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-ui.yaml
@@ -38,7 +38,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   name: {{ include "myapp.fullname" . }}-ui
   labels:
     app.kubernetes.io/name: {{ include "myapp.name" . }}
@@ -57,7 +56,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app.kubernetes.io/name: {{ include "myapp.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -104,6 +102,5 @@ spec:
               value: "user-interface/ui-chassis-spring-{{ .Values.egeria.version}}.jar"
       restartPolicy: Always
 
-status: {}
 ...
 {{ end }}

--- a/charts/odpi-egeria-lab/templates/egeria-uistatic.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-uistatic.yaml
@@ -66,7 +66,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   name: {{ include "myapp.fullname" . }}-uistatic
   labels:
     app.kubernetes.io/name: {{ include "myapp.name" . }}
@@ -85,7 +84,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app.kubernetes.io/name: {{ include "myapp.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -131,7 +129,6 @@ spec:
         - name: confd-vol
           emptyDir: { }
 
-status: {}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/odpi-egeria-lab/templates/jupyter.yaml
+++ b/charts/odpi-egeria-lab/templates/jupyter.yaml
@@ -29,7 +29,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   name: {{ include "myapp.fullname" . }}-jupyter
   labels:
     app.kubernetes.io/name: {{ include "myapp.name" . }}
@@ -138,5 +137,4 @@ spec:
 {{ if .Values.egeria.storageClass }}
   storageClassName: {{ .Values.jupyter.StorageClass }}
 {{ end }}
-status: {}
 ...

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -38,6 +38,12 @@ egeria:
   # Set to 'true' to deploy the Egeria UI, but note the configuration may not work properly
   egeriaui: true
 
+# Additional connectors/libraries to be made available in egeria server chassis containers
+# This is just an example. You can have a list of connectors
+#downloads:
+  #- url: https://search.maven.org/remotecontent?filepath=org/odpi/egeria/egeria-connector-xtdb/3.9/egeria-connector-xtdb-3.9-jar-with-dependencies.jar
+  #  filename: egeria-connector-xtdb-3.9-jar-with-dependencies.jar
+
 jupyter:
   # Sleep this long after configuring notebook environment - to aid debug
   scriptSleepBefore: "0"


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Now supports dynamic downloading of additional connectors to egeria platforms - for example xtdb, strimzi etc

To use
helm install .......blah blah -f ~/etc/connector.yaml

Where that file contains
```
downloads:
  - url: https://search.maven.org/remotecontent?filepath=org/odpi/egeria/egeria-connector-xtdb/3.9/egeria-connector-xtdb-3.9-jar-with-dependencies.jar
    filename: egeria-connector-xtdb-3.9-jar-with-dependencies.jar
```

Multiple connectors can be specified

Done
 - lab chart
 - base chart
  
  This replaces PR #127 
  
  This makes it easier to experiment with new notebooks that make use of any of the egeria connectors, open source or proprietary. If we add notebooks to coco Pharma that require these connectors, we may update the defaults for the lab chart accordingly 