### PR TITLE
Updates for connector downloading

### DIFF
--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-base
 description: Egeria simple deployment (platform, react UI)
 apiVersion: v2
-version: 3.10.0
+version: 3.11.0-prerelease.0
 appVersion: "3.10"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-base
 description: Egeria simple deployment (platform, react UI)
 apiVersion: v2
-version: 3.11.0-prerelease.0
+version: 3.11.0-prerelease.1
 appVersion: "3.10"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-base/templates/env.yaml
+++ b/charts/egeria-base/templates/env.yaml
@@ -28,7 +28,7 @@ data:
   # Server autostart
   POSTCONFIG_STARTUP_SERVER_LIST: {{ .Values.egeria.serverName }},{{ .Values.egeria.viewServerName }}
   STARTUP_CONFIGMAP: {{ .Release.Name }}-autostart
-  LOADER_PATH: /extlib,/deployments/server/lib,/opt/egeria/connectors
+  LOADER_PATH: /extlib,/deployments/server/extralib,/deployments/server/lib
   # Additional values inserted by user
 {{- with .Values.extraEnv }}
 {{ tpl . $ | indent 2 }}

--- a/charts/egeria-base/templates/env.yaml
+++ b/charts/egeria-base/templates/env.yaml
@@ -28,7 +28,7 @@ data:
   # Server autostart
   POSTCONFIG_STARTUP_SERVER_LIST: {{ .Values.egeria.serverName }},{{ .Values.egeria.viewServerName }}
   STARTUP_CONFIGMAP: {{ .Release.Name }}-autostart
-  LOADER_PATH: /extlib,/deployments/server/lib
+  LOADER_PATH: /extlib,/deployments/server/lib,/opt/egeria/connectors
   # Additional values inserted by user
 {{- with .Values.extraEnv }}
 {{ tpl . $ | indent 2 }}

--- a/charts/egeria-base/templates/platform.yaml
+++ b/charts/egeria-base/templates/platform.yaml
@@ -61,7 +61,7 @@ spec:
         app.kubernetes.io/component: platform
     spec:
     {{- include "egeria.security" . | nindent 6 }}
-{{ if .Values.downloads }}
+{{ if .Values.extralibs }}
       initContainers:
         - name: init-connector
           image: "{{ if (.Values.image.configure.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.configure.registry | default .Values.imageDefaults.registry }}/{{ end }}\
@@ -73,13 +73,13 @@ spec:
             - "/bin/bash"
             - "-c"
             - >
-              cd /opt/egeria/connectors &&
-{{ range .Values.downloads }}
+              cd  /deployments/server/extralib &&
+{{ range .Values.extralibs }}
               curl --location {{ .url | quote }} --output {{ .filename | quote }} &&
 {{ end }}
               echo "Downloads complete."
           volumeMounts:
-            - mountPath: /opt/egeria/connectors
+            - mountPath:  /deployments/server/extralib
               name: egeria-connector-volume
 {{ end }}
       containers:
@@ -136,7 +136,7 @@ spec:
           {{ end }}
             - name: extlib
               mountPath: /extlib
-            - mountPath: /opt/egeria/connectors
+            - mountPath:  /deployments/server/extralib
               name: egeria-connector-volume
               readOnly: true
       restartPolicy: Always

--- a/charts/egeria-base/templates/platform.yaml
+++ b/charts/egeria-base/templates/platform.yaml
@@ -61,6 +61,27 @@ spec:
         app.kubernetes.io/component: platform
     spec:
     {{- include "egeria.security" . | nindent 6 }}
+{{ if .Values.downloads }}
+      initContainers:
+        - name: init-connector
+          image: "{{ if (.Values.image.configure.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.configure.registry | default .Values.imageDefaults.registry }}/{{ end }}\
+                  {{ if (.Values.image.configure.namespace | default .Values.imageDefaults.namespace) }}{{ .Values.image.configure.namespace | default .Values.imageDefaults.namespace }}/{{ end }}\
+                  {{ .Values.image.configure.name }}\
+                  :{{ .Values.image.configure.tag | default .Values.imageDefaults.tag }}"
+          imagePullPolicy: {{ .Values.image.configure.pullPolicy | default .Values.imageDefaults.pullPolicy }}
+          command:
+            - "/bin/bash"
+            - "-c"
+            - >
+              cd /opt/egeria/connectors &&
+{{ range .Values.downloads }}
+              curl --location {{ .url | quote }} --output {{ .filename | quote }} &&
+{{ end }}
+              echo "Downloads complete."
+          volumeMounts:
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+{{ end }}
       containers:
         - name: egeria
           image: "{{ if (.Values.image.egeria.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.egeria.registry | default .Values.imageDefaults.registry }}/{{ end }}\
@@ -115,11 +136,16 @@ spec:
           {{ end }}
             - name: extlib
               mountPath: /extlib
+            - mountPath: /opt/egeria/connectors
+              name: egeria-connector-volume
+              readOnly: true
       restartPolicy: Always
       volumes:
         - name: extlib
           configMap:
             name: {{ .Release.Name }}-extlib
+        - name: egeria-connector-volume
+          emptyDir: {}
       securityContext:
         {  }
   {{ if .Values.egeria.persistence }}

--- a/charts/egeria-base/values.yaml
+++ b/charts/egeria-base/values.yaml
@@ -29,6 +29,12 @@ egeria:
   # will be done either if set to false. Defaults to true
   config: true
 
+# Additional connectors/libraries to be made available in egeria server chassis containers
+# This is just an example. You can have a list of connectors
+#downloads:
+#- url: https://search.maven.org/remotecontent?filepath=org/odpi/egeria/egeria-connector-xtdb/3.9/egeria-connector-xtdb-3.9-jar-with-dependencies.jar
+#  filename: egeria-connector-xtdb-3.9-jar-with-dependencies.jar
+
 # --- Additional environment variables - inserted directly into configmap. Can use helm template directives
 #extraEnv: |
 #  VAR1: value1

--- a/charts/egeria-base/values.yaml
+++ b/charts/egeria-base/values.yaml
@@ -31,7 +31,7 @@ egeria:
 
 # Additional connectors/libraries to be made available in egeria server chassis containers
 # This is just an example. You can have a list of connectors
-#downloads:
+#extralibs:
 #- url: https://search.maven.org/remotecontent?filepath=org/odpi/egeria/egeria-connector-xtdb/3.9/egeria-connector-xtdb-3.9-jar-with-dependencies.jar
 #  filename: egeria-connector-xtdb-3.9-jar-with-dependencies.jar
 

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v2
-version: 3.11.0-prerelease.2
+version: 3.11.0-prerelease.3
 appVersion: "3.10"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/templates/egeria-core.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-core.yaml
@@ -64,7 +64,7 @@ spec:
       volumes:
         - name: egeria-connector-volume
           emptyDir: {}
-{{ if .Values.downloads }}
+{{ if .Values.extralibs }}
       initContainers:
         - name: init-connector
           image: "{{ if (.Values.image.configure.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.configure.registry | default .Values.imageDefaults.registry }}/{{ end }}\
@@ -76,13 +76,13 @@ spec:
             - "/bin/bash"
             - "-c"
             - >
-                cd /opt/egeria/connectors &&
-{{ range .Values.downloads }}
+                cd /deployments/server/extralib &&
+{{ range .Values.extralibs }}
                 curl --location {{ .url | quote }} --output {{ .filename | quote }} &&
 {{ end }}
                 echo "Downloads complete."
           volumeMounts:
-            - mountPath: /opt/egeria/connectors
+            - mountPath: /deployments/server/extralib
               name: egeria-connector-volume
 {{ end }}
       containers:
@@ -101,7 +101,7 @@ spec:
               value:  "true"
             {{ end }}
             - name: "LOADER_PATH"
-              value: "/deployments/server/lib,/opt/egeria/connectors"
+              value: "/deployments/server/extralib,/deployments/server/lib"
           ports:
             - containerPort: 9443
           {{ if .Values.debug.egeriaJVM }}
@@ -119,7 +119,7 @@ spec:
             - mountPath: "/deployments/data"
               name: {{ .Release.Name }}-core-data
           {{ end }}
-            - mountPath: /opt/egeria/connectors
+            - mountPath: /deployments/server/extralib
               name: egeria-connector-volume
               readOnly: true
       restartPolicy: Always

--- a/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
@@ -64,7 +64,7 @@ spec:
       volumes:
         - name: egeria-connector-volume
           emptyDir: {}
-{{ if .Values.downloads }}
+{{ if .Values.extralibs }}
       initContainers:
         - name: init-connector
           image: "{{ if (.Values.image.configure.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.configure.registry | default .Values.imageDefaults.registry }}/{{ end }}\
@@ -76,13 +76,13 @@ spec:
             - "/bin/bash"
             - "-c"
             - >
-                cd /opt/egeria/connectors &&
-{{ range .Values.downloads }}
+                cd /deployments/server/extralib &&
+{{ range .Values.extralibs }}
                 curl --location {{ .url | quote }} --output {{ .filename | quote }} &&
 {{ end }}
                 echo "Downloads complete."
           volumeMounts:
-            - mountPath: /opt/egeria/connectors
+            - mountPath: /deployments/server/extralib
               name: egeria-connector-volume
 {{ end }}
       containers:
@@ -101,7 +101,7 @@ spec:
               value:  "true"
             {{ end }}
             - name: "LOADER_PATH"
-              value: "/deployments/server/lib,/opt/egeria/connectors"
+              value: "/deployments/server/extralib,/deployments/server/lib"
           ports:
             - containerPort: 9443
           {{ if .Values.debug.egeriaJVM }}
@@ -119,7 +119,7 @@ spec:
             - mountPath: "/deployments/data"
               name: {{ .Release.Name }}-datalake-data
           {{ end }}
-            - mountPath: /opt/egeria/connectors
+            - mountPath: /deployments/server/extralib
               name: egeria-connector-volume
               readOnly: true
       restartPolicy: Always

--- a/charts/odpi-egeria-lab/templates/egeria-dev.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-dev.yaml
@@ -65,7 +65,7 @@ spec:
       volumes:
         - name: egeria-connector-volume
           emptyDir: {}
-{{ if .Values.downloads }}
+{{ if .Values.extralibs }}
       initContainers:
         - name: init-connector
           image: "{{ if (.Values.image.configure.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.configure.registry | default .Values.imageDefaults.registry }}/{{ end }}\
@@ -78,13 +78,13 @@ spec:
             - "/bin/bash"
             - "-c"
             - >
-                cd /opt/egeria/connectors &&
-{{ range .Values.downloads }}
+                cd /deployments/server/extralib &&
+{{ range .Values.extralibs }}
                 curl --location {{ .url | quote }} --output {{ .filename | quote }} &&
 {{ end }}
                 echo "Downloads complete."
           volumeMounts:
-            - mountPath: /opt/egeria/connectors
+            - mountPath: /deployments/server/extralib
               name: egeria-connector-volume
 {{ end }}
       containers:
@@ -103,7 +103,7 @@ spec:
                value:  "true"
             {{ end }}
             - name: "LOADER_PATH"
-              value: "/deployments/server/lib,/opt/egeria/connectors"
+              value: "/deployments/server/extralib,/deployments/server/lib"
           ports:
             - containerPort: 9443
             {{ if .Values.debug.egeriaJVM }}
@@ -121,7 +121,7 @@ spec:
             - mountPath: "/deployments/data"
               name: {{ .Release.Name }}-dev-data
           {{ end }}
-            - mountPath: /opt/egeria/connectors
+            - mountPath: /deployments/server/extralib
               name: egeria-connector-volume
               readOnly: true
       restartPolicy: Always

--- a/charts/odpi-egeria-lab/templates/egeria-factory.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-factory.yaml
@@ -65,7 +65,7 @@ spec:
       volumes:
         - name: egeria-connector-volume
           emptyDir: {}
-{{ if .Values.downloads }}
+{{ if .Values.extralibs }}
       initContainers:
         - name: init-connector
           image: "{{ if (.Values.image.configure.registry | default .Values.imageDefaults.registry) }}{{ .Values.image.configure.registry | default .Values.imageDefaults.registry }}/{{ end }}\
@@ -77,13 +77,13 @@ spec:
             - "/bin/bash"
             - "-c"
             - >
-                cd /opt/egeria/connectors &&
-{{ range .Values.downloads }}
+                cd /deployments/server/extralib &&
+{{ range .Values.extralibs }}
                 curl --location {{ .url | quote }} --output {{ .filename | quote }} &&
 {{ end }}
                 echo "Downloads complete."
           volumeMounts:
-            - mountPath: /opt/egeria/connectors
+            - mountPath: /deployments/server/extralib
               name: egeria-connector-volume
 {{ end }}
       containers:
@@ -102,7 +102,7 @@ spec:
               value:  "true"
             {{ end }}
             - name: "LOADER_PATH"
-              value: "/deployments/server/lib,/opt/egeria/connectors"
+              value: "/deployments/server/extralib,/deployments/server/lib"
           ports:
             - containerPort: 9443
             {{ if .Values.debug.egeriaJVM }}
@@ -120,7 +120,7 @@ spec:
             - mountPath: "/deployments/data"
               name: {{ .Release.Name }}-factory-data
           {{ end }}
-            - mountPath: /opt/egeria/connectors
+            - mountPath: /deployments/server/extralib
               name: egeria-connector-volume
               readOnly: true
       restartPolicy: Always

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -40,7 +40,7 @@ egeria:
 
 # Additional connectors/libraries to be made available in egeria server chassis containers
 # This is just an example. You can have a list of connectors
-#downloads:
+#extralibs:
   #- url: https://search.maven.org/remotecontent?filepath=org/odpi/egeria/egeria-connector-xtdb/3.9/egeria-connector-xtdb-3.9-jar-with-dependencies.jar
   #  filename: egeria-connector-xtdb-3.9-jar-with-dependencies.jar
 


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

* Updates to fix connector downloading (some files were not checked in)
* Changed 'downloads' to 'extralibs' -- we've talked about other kinds of downloads, which would need to be put in other places. this makes it clearer that these files will be added into the class path of the server chassis
* Moved the mount directory from /opt/egeria/connectors to /deployments/server/extralib. to be alongside the regular lib directory in the UBI-8 openjdk container

Behaviour if bad connector specified:

Pod will show an init error:
```
egeria-base-platform-0                      0/1     Init:Error          0          33s
```
Pod log will show how curl (used to download connector) failed ie:
```
 kubectl logs egeria-base-platform-0 -c init-connector
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   138  100   138    0     0    345      0 --:--:-- --:--:-- --:--:--   345
100 87.9M  100 87.9M    0     0  92.0M      0 --:--:-- --:--:-- --:--:--  288M
curl: (3) bad range specification in URL position 87:
https://oss.sonatype.org/service/local/repositories/snapshots/content/org/odpi/egeria[…]SNAPSHOT/egeria-connector-postgres-3.6-20220221.223312-1.jar
```

This error would need to be corrected & the chart deployed (it is not picked up dynamically - that would be an enhancement)

both a filename and url must be specified - there is no default filename, and the download will fail if filename empty.

Behaviour with good connector:

Init will be very quick, and pod will progress to:
```
egeria-base-platform-0                      1/1     Running    0          105s
```
We can see the files are present in /deployments/server/extralib
```
kubectl exec -it egeria-base-platform-0 -- ls /deployments/server/extralib
Defaulted container "egeria" out of: egeria, init-connector (init)
egeria-connector-postgres.jar  egeria-connector-xtdb-3.9-jar-with-dependencies.jar  postgresql.jar
```

We can also see that the LOADER_PATH is correctly set to allow egeria to find these libraries:
```
➜  charts git:(connectors) kubectl get pods
NAME                                        READY   STATUS        RESTARTS   AGE
base-strimzi-kafka-0                        1/1     Terminating   0          6m28s
base-strimzi-zookeeper-0                    0/1     Pending       0          0s
egeria-base-config-ctc8m                    0/1     Init:0/2      0          10s
egeria-base-platform-0                      0/1     Init:0/1      0          10s
egeria-base-presentation-77c969c598-hwkts   0/1     Running       0          10s
➜  charts git:(connectors) kubectl exec -it egeria-base-platform-0 -- /bin/sh
Defaulted container "egeria" out of: egeria, init-connector (init)
sh-4.4$ ls /deployments/server/
extralib  lib  server-chassis-spring-3.10.jar
sh-4.4$ ls /deployments/server/extralib
egeria-connector-postgres.jar  egeria-connector-xtdb-3.9-jar-with-dependencies.jar  postgresql.jar
sh-4.4$ echo $LOADER_PATH
/extlib,/deployments/server/extralib,/deployments/server/lib
```