### PR TITLE
odpi/egeria#6812 Update kafka version to match strimzi

### DIFF
--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-base
 description: Egeria simple deployment (platform, react UI)
 apiVersion: v2
-version: 3.11.0-prerelease.3
+version: 3.11.0-prerelease.4
 appVersion: "3.11"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-base/templates/kafka-cluster.yaml
+++ b/charts/egeria-base/templates/kafka-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Release.Name }}-strimzi
 spec:
   kafka:
-    version: 3.0.0
+    version: 3.2.0
     replicas: 1
     listeners:
       - name: plain
@@ -18,8 +18,6 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "3.0"
-      inter.broker.protocol.version: "3.0"
       auto.create.topics.enable: "true"
     readinessProbe:
       initialDelaySeconds: 15

--- a/charts/egeria-cts/Chart.yaml
+++ b/charts/egeria-cts/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-cts
 description: Egeria Conformance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.11.0-prerelease.1
+version: 3.11.0-prerelease.2
 appVersion: "3.11"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-cts/templates/kafka-cluster.yaml
+++ b/charts/egeria-cts/templates/kafka-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Release.Name }}-strimzi
 spec:
   kafka:
-    version: 3.0.0
+    version: 3.2.0
     replicas: 1
     listeners:
       - name: plain
@@ -18,8 +18,6 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "3.0"
-      inter.broker.protocol.version: "3.0"
       auto.create.topics.enable: "true"
     readinessProbe:
       initialDelaySeconds: 15

--- a/charts/egeria-pts/Chart.yaml
+++ b/charts/egeria-pts/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-pts
 description: Egeria Performance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.11.0-prerelease.1
+version: 3.11.0-prerelease.2
 appVersion: "3.11"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-pts/templates/kafka-cluster.yaml
+++ b/charts/egeria-pts/templates/kafka-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Release.Name }}-strimzi
 spec:
   kafka:
-    version: 3.0.0
+    version: 3.2.0
     replicas: 1
     listeners:
       - name: plain
@@ -18,8 +18,6 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "3.0"
-      inter.broker.protocol.version: "3.0"
       auto.create.topics.enable: "true"
     readinessProbe:
       initialDelaySeconds: 15

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v2
-version: 3.11.0-prerelease.5
+version: 3.11.0-prerelease.6
 appVersion: "3.11"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
+++ b/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Release.Name }}-strimzi
 spec:
   kafka:
-    version: 3.0.0
+    version: 3.2.0
     replicas: 1
     listeners:
       - name: plain
@@ -18,8 +18,6 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "3.0"
-      inter.broker.protocol.version: "3.0"
       auto.create.topics.enable: "true"
     readinessProbe:
       initialDelaySeconds: 15


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

* Updates kafka version in custom resource for each chart to 3.2.0 (close to egeria build which is 3.2.1)
* Removes hardcoded formats - these will default correctly based on kafka version
* Updates chart versions for publish/test