### PR TITLE
#179 add option to set password for jupyter

### DIFF
--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v2
-version: 3.11.0
+version: 3.11.1
 appVersion: "3.11"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/templates/jupyter.yaml
+++ b/charts/odpi-egeria-lab/templates/jupyter.yaml
@@ -87,6 +87,18 @@ spec:
               value: "YES"
             - name: DOCKER_STACKS_JUPYTER_CMD
               value: "lab --notebook-dir=/home/jovyan/work"
+            # If value not passed, a password will be generated, otherwise get from configmap (and must exist)
+            {{ if .Values.jupyter.tokenSecret }}
+            - name: JUPYTER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.jupyter.tokenSecret }}
+                  key: password
+                  optional: false
+            {{ else if .Values.jupyter.tokenPlain }}
+            - name: JUPYTER_TOKEN
+              value: {{ .Values.jupyter.tokenPlain }}
+            {{ end }}
             # Contains the truststore from Egeria self-signed certs, in .pem format
             #- name: REQUESTS_CA_BUNDLE
             #  value: "/home/jovyan/ssl/truststore.pem"

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -50,6 +50,11 @@ jupyter:
   scriptSleepAfter: "0"
   # Size for jupyter work
   storageSize: "1Gi"
+  # If assigned, will use the 'password' entry as the name of the secret to seed the Jupyter password
+  # to create: kubectl create secret generic jupyter-lab-secret --from-literal=password='s3cr3t!'
+  # tokenSecret:
+  # If passwordSecret not set, but passwordPlain is, we use this as cleartext **INSECURE**
+  # tokenPlain:
 
 debug:
   egeriaJVM: false


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Adds ability to set the initial password for Jupyter notebooks.

The approach is now (in priority order):

**1. Using a Kubernetes secret to manage the password**

If value`jupyter.tokenSecret` is set, it must refer to the name of the secret in the current namespace which contains a single key `password` with the value set to the value required

For example:
```
kubectl create secret generic jupyter-lab-secret --from-literal=password='s3cr3t!'
helm install lab egeria/odpi-egeria-lab  --set jupyter.tokenSecret=jupyter-lab-secret
```

**2. Using a password literal**

If value `jupyter.tokenPlain` is set, it is used as the literal password for jupyter. 

for example:
```
helm install lab egeria/odpi-egeria-lab  --set jupyter.tokenPlain='letme1n2'
```
_NOTE: This is less secure as it is easily viewable with minimal privileges both in any helm value values, as well as in the k8s environment_

**3. Using an auto generated password (default)**

If neither of the above values are set, the existing behaviour is preserved. A token is auto-generated.

NOTE: At this point, the generated value is not stored, so when the pod restarts yet another value is created. This may be fixed in a further update (other options do not have this issue)

FINAL NOTES

Partial fix for #179 

Remember to issue
```
helm repo update
```

prior to trying new chart versions