### PR TITLE
#192 fix platform/presentation template handling of servicePort / CR

### DIFF
--- a/charts/egeria-base/templates/platform.yaml
+++ b/charts/egeria-base/templates/platform.yaml
@@ -17,7 +17,7 @@ spec:
   ports:
     - port: 9443
       targetPort: 9443
-      {{- if ( eq  .Values.service.type "NodePort" ) -}}
+      {{- if ( eq  .Values.service.type "NodePort" ) }}
       nodePort: {{ .Values.service.nodeport.platform }}
       {{- end }}
   {{ if .Values.egeria.debug }}

--- a/charts/egeria-base/templates/presentation.yaml
+++ b/charts/egeria-base/templates/presentation.yaml
@@ -17,7 +17,7 @@ spec:
   ports:
     - port: 8091
       targetPort: 8091
-      {{- if ( eq  .Values.service.type "NodePort" ) -}}
+      {{- if ( eq  .Values.service.type "NodePort" ) }}
       nodePort: {{ .Values.service.nodeport.presentation }}
       {{- end }}
   selector:


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Fixes template issue when service.type was set (ie to NodePort)

Template incorrectly stripped a CR, resulting in concatentation & hence invalid yaml