### PR TITLE
odpi/egeria#6898 initial prerelease for 3.12

### DIFF
--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -4,8 +4,8 @@
 name: egeria-base
 description: Egeria simple deployment (platform, react UI)
 apiVersion: v2
-version: 3.11.1
-appVersion: "3.11"
+version: 3.12.0-prerelease.0
+appVersion: "3.12"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
   - odpi, egeria, base, simple
@@ -17,6 +17,6 @@ maintainers:
     email: nigel.l.jones+git@gmail.com
 dependencies:
   - name: strimzi-kafka-operator
-    version: 0.30.0
+    version: 0.31.1
     repository: https://strimzi.io/charts/
     condition: strimzi.enabled

--- a/charts/egeria-base/templates/kafka-cluster.yaml
+++ b/charts/egeria-base/templates/kafka-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Release.Name }}-strimzi
 spec:
   kafka:
-    version: 3.2.0
+    version: 3.2.3
     replicas: 1
     listeners:
       - name: plain

--- a/charts/egeria-base/values.yaml
+++ b/charts/egeria-base/values.yaml
@@ -6,7 +6,7 @@
 egeria:
   # Set to INFO, WARNING, DEBUG if needed
   logging: 
-  version: "3.11"
+  version: "3.12"
   repositoryType: "local-graph-repository"
   debug: false
   persistence: true

--- a/charts/egeria-cts/Chart.yaml
+++ b/charts/egeria-cts/Chart.yaml
@@ -4,8 +4,8 @@
 name: egeria-cts
 description: Egeria Conformance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.11.0
-appVersion: "3.11"
+version: 3.12.0-prerelease.0
+appVersion: "3.12"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
   - odpi, egeria, cts
@@ -19,7 +19,7 @@ maintainers:
     email: nigel.l.jones+git@gmail.com
 dependencies:
   - name: strimzi-kafka-operator
-    version: 0.30.0
+    version: 0.31.1
     repository: https://strimzi.io/charts/
     condition: strimzi.enabled
 

--- a/charts/egeria-cts/templates/kafka-cluster.yaml
+++ b/charts/egeria-cts/templates/kafka-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Release.Name }}-strimzi
 spec:
   kafka:
-    version: 3.2.0
+    version: 3.2.3
     replicas: 1
     listeners:
       - name: plain

--- a/charts/egeria-cts/values.yaml
+++ b/charts/egeria-cts/values.yaml
@@ -68,7 +68,7 @@ resources:
 imageDefaults:
   registry: quay.io
   namespace: odpi
-  tag: "3.11"
+  tag: "3.12"
   pullPolicy: IfNotPresent
 
 # The following section defines all DOCKER images being used by this chart. Normally they should be left as is,

--- a/charts/egeria-pts/Chart.yaml
+++ b/charts/egeria-pts/Chart.yaml
@@ -4,8 +4,8 @@
 name: egeria-pts
 description: Egeria Performance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.11.0
-appVersion: "3.11"
+version: 3.12.0-prerelease.0
+appVersion: "3.12"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
   - odpi, egeria, pts
@@ -19,7 +19,7 @@ maintainers:
     email: nigel.l.jones+git@gmail.com
 dependencies:
   - name: strimzi-kafka-operator
-    version: 0.30.0
+    version: 0.31.1
     repository: https://strimzi.io/charts/
     condition: strimzi.enabled
 

--- a/charts/egeria-pts/templates/kafka-cluster.yaml
+++ b/charts/egeria-pts/templates/kafka-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Release.Name }}-strimzi
 spec:
   kafka:
-    version: 3.2.0
+    version: 3.2.3
     replicas: 1
     listeners:
       - name: plain

--- a/charts/egeria-pts/values.yaml
+++ b/charts/egeria-pts/values.yaml
@@ -74,7 +74,7 @@ resources:
 imageDefaults:
   registry: quay.io
   namespace: odpi
-  tag: "3.11"
+  tag: "3.12"
   pullPolicy: IfNotPresent
 
 # Normally we install the strimzi operator as part of the Chart. However this requires admin permissions, and

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,8 +4,8 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v2
-version: 3.11.1
-appVersion: "3.11"
+version: 3.12.0-prerelease.0
+appVersion: "3.12"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
   - odpi, egeria, lab, jupyter, notebook
@@ -19,6 +19,6 @@ maintainers:
     email: nigel.l.jones+git@gmail.com
 dependencies:
   - name: strimzi-kafka-operator
-    version: 0.30.0
+    version: 0.31.1
     repository: https://strimzi.io/charts/
     condition: strimzi.enabled

--- a/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
+++ b/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Release.Name }}-strimzi
 spec:
   kafka:
-    version: 3.2.0
+    version: 3.2.3
     replicas: 1
     listeners:
       - name: plain

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -31,7 +31,7 @@ service:
 egeria:
   #logging: OFF
   development: true
-  version: "3.11"
+  version: "3.12"
   #repositoryType: "local-graph-repository"
   repositoryType: "in-memory-repository"
   # See https://github.com/odpi/egeria-charts/issues/56 for status of the Egeria UI (polymer) in this environment
@@ -89,10 +89,10 @@ image:
     #registry: docker.io
     #namespace: jupyter
     name: jupyter
-    tag: "lab-3.4.5"
+    tag: "lab-3.4.7"
   uistatic:
     name: egeria-ui
-    tag: "3.2.0"
+    tag: "3.2.2"
   nginx:
     registry: public.ecr.aws
     name: nginx/nginx


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Initial pre-release for 3.12
- Updates chart versions to 3.12-prerelease.0
- Updates egeria image to 3.12 (all)
- Updates strimzi to 0.31.1 (all)
- Updates kafka to 3.2.3 (all)
- Updates jupyter lab to 3.4.7 (lab)
- Updates egeria polymer UI to 3.2.2 (lab)