### PR TITLE
#178 allow notebook git tag to be specified for checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
           version: v3.4.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,6 @@ jobs:
           version: v3.4.0
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.4.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/egeria-base/templates/NOTES.txt
+++ b/charts/egeria-base/templates/NOTES.txt
@@ -1,4 +1,4 @@
-ODPi Egeria
+LF AI & Data Egeria
 ---
 
 Egeria base environment has now been deployed to Kubernetes.
@@ -11,8 +11,8 @@ By default a single platform is created using the latest release of Egeria, with
 metadata server 'mds1' and a view server 'view1'. The UI organization name is 'org'.
 A job is started to perform this configuration and may take up to 10 minutes to complete.
 
-Please provide any feeback via a github issue at https://github.com/odpi/egeria or 
-join us on slack via https://http://slack.lfai.foundation
+Please provide any feeback via a github issue at https://github.com/odpi/egeria-charts or
+join us on slack via https://slack.lfaidata.foundation
 
 - The ODPi Egeria team
 

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v2
-version: 3.13.1-prerelease.0
+version: 3.13.1
 appVersion: "3.13"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v2
-version: 3.13.0-prerelease.0
+version: 3.13.0-prerelease.1B
 appVersion: "3.13"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/scripts/setup-notebooks.sh
+++ b/charts/odpi-egeria-lab/scripts/setup-notebooks.sh
@@ -13,7 +13,7 @@ echo "-- Setting up Egeria notebook environment --"
 # Pause for debugging
 if [ ! -z "$SCRIPT_SLEEP_BEFORE" ]; then
   echo "-- Sleeping for $SCRIPT_SLEEP_BEFORE seconds"
-  sleep $SCRIPT_SLEEP_BEFORE
+  sleep "$SCRIPT_SLEEP_BEFORE"
 fi
 
 # First reset permissions (every time)
@@ -22,7 +22,7 @@ echo "-- Fixing user setup"
 
 if [ "$(id -u)" -ge 10000 ]; then
  cat /etc/passwd | sed -e "s/^$NB_USER:/builder:/" > /tmp/passwd
- echo "$NB_USER:x:`id -u`:`id -g`:,,,:/home/$NB_USER:/bin/bash" >> /tmp/passwd
+ echo "$NB_USER:x:$(id -u):$(id -g):,,,:/home/$NB_USER:/bin/bash" >> /tmp/passwd
  cat /tmp/passwd > /etc/passwd
  rm /tmp/passwd
  fi
@@ -33,40 +33,40 @@ git config --global --add safe.directory '*'
 
 # Only do this setup once ...
 
-if [ ! -r $STATUS ]
+if [ ! -r "$STATUS" ]
 then
 
   # Cleanup any partial setup
   echo "-- Cleaning up from any prior partial setup"
-  rm -fr ${LOCATION}/lost+found
-  rm -fr ${LOCATION}/.git
+  rm -fr "${LOCATION}/lost+found"
+  rm -fr "${LOCATION}/.git"
 
   # Shallow clone - just to get latest files, not history
 
   echo "-- Cloning from ${GITREPO} into ${LOCATION} ..."
   cd ${LOCATION}/.. || return
-  git clone --depth 1 ${GITREPO} ${LOCATION}
-  cd ${LOCATION} || return
+  git clone --depth 1 "${GITREPO}" "${LOCATION}"
+  cd "${LOCATION}" || return
   git pull
   # We also checkout the requested tag if specified - but only during initial setup
   echo "-- Switching to requested git tag "
-  if [ ! -z ${GIT_TAG_NOTEBOOKS} ]
+  if [ ! -z "${GIT_TAG_NOTEBOOKS}" ]
   then
     git fetch
-    git checkout ${GIT_TAG_NOTEBOOKS}
+    git checkout "${GIT_TAG_NOTEBOOKS}"
   fi
   # Mark as done (this is only for the content written to our persistent volume, ie git contents)
-  mkdir -p touch $STATUS
+  mkdir -p touch "$STATUS"
 fi
 
 # Install additional packages if we've just pulled from git
 echo "-- Installing extra conda packages"
-conda install --yes --file ${LOCATION}/requirements.txt
+conda install --yes --file "${LOCATION}/requirements.txt"
 
 # Pause for debugging
 if [ ! -z "$SCRIPT_SLEEP_AFTER" ]; then
   echo "-- Sleeping for $SCRIPT_SLEEP_AFTER seconds"
-  sleep $SCRIPT_SLEEP_AFTER
+  sleep "$SCRIPT_SLEEP_AFTER"
 fi
 
 echo "-- Egeria notebook setup complete --"

--- a/charts/odpi-egeria-lab/scripts/setup-notebooks.sh
+++ b/charts/odpi-egeria-lab/scripts/setup-notebooks.sh
@@ -6,50 +6,71 @@
 : "${GITREPO:=https://github.com/odpi/egeria-jupyter-notebooks}"
 : "${GITBRANCH:=main}"
 : "${LOCATION:=/home/jovyan/work}"
+: "${STATUS:=/home/jovyan/work/.setupComplete}"
 
-echo "-- Setting up Egeria notebooks --"
+echo "-- Setting up Egeria notebook environment --"
 
 # Pause for debugging
 if [ ! -z "$SCRIPT_SLEEP_BEFORE" ]; then
-  echo "Sleeping for $SCRIPT_SLEEP_BEFORE seconds"
+  echo "-- Sleeping for $SCRIPT_SLEEP_BEFORE seconds"
   sleep $SCRIPT_SLEEP_BEFORE
 fi
 
-# Shallow clone - just to get latest files, not history
-if [ ! -r ${LOCATION}/.git ]
+# First reset permissions (every time)
+# Ensure that assigned uid has entry in /etc/passwd.
+echo "-- Fixing user setup"
+
+if [ "$(id -u)" -ge 10000 ]; then
+ cat /etc/passwd | sed -e "s/^$NB_USER:/builder:/" > /tmp/passwd
+ echo "$NB_USER:x:`id -u`:`id -g`:,,,:/home/$NB_USER:/bin/bash" >> /tmp/passwd
+ cat /tmp/passwd > /etc/passwd
+ rm /tmp/passwd
+ fi
+
+# Disable file permission warnings - we're running in a container, and the
+# volume may not have our permissions
+git config --global --add safe.directory '*'
+
+# Only do this setup once ...
+
+if [ ! -r $STATUS ]
 then
-  echo "No git repo found in ${LOCATION}, cloning from ${GITREPO}..."
-  cd ${LOCATION}/..
-  # Cleanup lost and found and other directories - need to be empty for git
-  rm -fr ${LOCATION}/*
-  #git config --global --add safe.directory ${LOCATION}
+
+  # Cleanup any partial setup
+  echo "-- Cleaning up from any prior partial setup"
+  rm -fr ${LOCATION}/lost+found
+  rm -fr ${LOCATION}/.git
+
+  # Shallow clone - just to get latest files, not history
+
+  echo "-- Cloning from ${GITREPO} into ${LOCATION} ..."
+  cd ${LOCATION}/.. || return
   git clone --depth 1 ${GITREPO} ${LOCATION}
-  cd ${LOCATION}
+  cd ${LOCATION} || return
   git pull
-
-  # Install additional packages if we've just pulled from git
-  echo "-- Installing extra packages"
-  conda install --yes --file ${LOCATION}/requirements.txt && \
-       fix-permissions $CONDA_DIR && \
-       fix-permissions /home/$NB_USER
-
   # We also checkout the requested tag if specified - but only during initial setup
+  echo "-- Switching to requested git tag "
   if [ ! -z ${GIT_TAG_NOTEBOOKS} ]
   then
     git fetch
     git checkout ${GIT_TAG_NOTEBOOKS}
   fi
-else
-  echo "Found git repo in ${LOCATION}, leaving as-is. update manually with 'git pull' or save work"
-
+  # Mark as done (this is only for the content written to our persistent volume, ie git contents)
+  mkdir -p touch $STATUS
 fi
+
+# Install additional packages if we've just pulled from git
+echo "-- Installing extra conda packages"
+conda install --yes --file ${LOCATION}/requirements.txt
 
 # Pause for debugging
 if [ ! -z "$SCRIPT_SLEEP_AFTER" ]; then
-  echo "Sleeping for $SCRIPT_SLEEP_AFTER seconds"
+  echo "-- Sleeping for $SCRIPT_SLEEP_AFTER seconds"
   sleep $SCRIPT_SLEEP_AFTER
 fi
 
 echo "-- Egeria notebook setup complete --"
+
+return 0
 
 

--- a/charts/odpi-egeria-lab/scripts/setup-notebooks.sh
+++ b/charts/odpi-egeria-lab/scripts/setup-notebooks.sh
@@ -11,7 +11,7 @@
 echo "-- Setting up Egeria notebook environment --"
 
 # Pause for debugging
-if [ ! -z "$SCRIPT_SLEEP_BEFORE" ]; then
+if [ -n "$SCRIPT_SLEEP_BEFORE" ]; then
   echo "-- Sleeping for $SCRIPT_SLEEP_BEFORE seconds"
   sleep "$SCRIPT_SLEEP_BEFORE"
 fi
@@ -50,7 +50,7 @@ then
   git pull
   # We also checkout the requested tag if specified - but only during initial setup
   echo "-- Switching to requested git tag "
-  if [ ! -z "${GIT_TAG_NOTEBOOKS}" ]
+  if [ -n "${GIT_TAG_NOTEBOOKS}" ]
   then
     git fetch
     git checkout "${GIT_TAG_NOTEBOOKS}"
@@ -64,7 +64,7 @@ echo "-- Installing extra conda packages"
 conda install --yes --file "${LOCATION}/requirements.txt"
 
 # Pause for debugging
-if [ ! -z "$SCRIPT_SLEEP_AFTER" ]; then
+if [ -n "$SCRIPT_SLEEP_AFTER" ]; then
   echo "-- Sleeping for $SCRIPT_SLEEP_AFTER seconds"
   sleep "$SCRIPT_SLEEP_AFTER"
 fi

--- a/charts/odpi-egeria-lab/scripts/setup-notebooks.sh
+++ b/charts/odpi-egeria-lab/scripts/setup-notebooks.sh
@@ -33,6 +33,12 @@ then
        fix-permissions $CONDA_DIR && \
        fix-permissions /home/$NB_USER
 
+  # We also checkout the requested tag if specified - but only during initial setup
+  if [ ! -z ${GIT_TAG_NOTEBOOKS} ]
+  then
+    git fetch
+    git checkout ${GIT_TAG_NOTEBOOKS}
+  fi
 else
   echo "Found git repo in ${LOCATION}, leaving as-is. update manually with 'git pull' or save work"
 

--- a/charts/odpi-egeria-lab/templates/NOTES.txt
+++ b/charts/odpi-egeria-lab/templates/NOTES.txt
@@ -1,4 +1,4 @@
-ODPi Egeria lab tutorial 
+LF AI & Data Egeria lab tutorial
 ---
 
 The Egeria tutorials have now been deployed to Kubernetes.
@@ -13,8 +13,8 @@ the correct 'addressofmycluster' to use.
 If you experience problems, check memory consumption on your nodes. A minimum of
 a 3 node cluster, 2GB per node; or a desktop environment with 6GB dedicated is recommended.
 
-Please provide any feeback via a github issue at https://github.com/odpi/egeria or 
-join us on slack via https://http://slack.lfai.foundation
+Please provide any feeback via a github issue at https://github.com/odpi/egeria-charts or
+join us on slack via https://slack.lfaiaidata.foundation
 
 - The ODPi Egeria team
 

--- a/charts/odpi-egeria-lab/templates/jupyter.yaml
+++ b/charts/odpi-egeria-lab/templates/jupyter.yaml
@@ -87,6 +87,11 @@ spec:
               value: "YES"
             - name: DOCKER_STACKS_JUPYTER_CMD
               value: "lab --notebook-dir=/home/jovyan/work"
+            # If value specified, we will checkout this tag if it exists
+            {{ if .Values.jupyter.gitTagForNotebooks }}
+            - name: GIT_TAG_NOTEBOOKS
+              value: {{ .Values.jupyter.gitTagForNotebooks }}
+            {{ end }}
             # If value not passed, a password will be generated, otherwise get from configmap (and must exist)
             {{ if .Values.jupyter.tokenSecret }}
             - name: JUPYTER_TOKEN

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -55,6 +55,8 @@ jupyter:
   # tokenSecret:
   # If passwordSecret not set, but passwordPlain is, we use this as cleartext **INSECURE**
   # tokenPlain:
+  # Git tag to checkout in the egeria-jupyter repo
+  gitTagForNotebooks: "main"
 
 debug:
   egeriaJVM: false

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -55,8 +55,9 @@ jupyter:
   # tokenSecret:
   # If passwordSecret not set, but passwordPlain is, we use this as cleartext **INSECURE**
   # tokenPlain:
+  # ----
   # Git tag to checkout in the egeria-jupyter repo
-  gitTagForNotebooks: "main"
+  gitTagForNotebooks: "v313"
 
 debug:
   egeriaJVM: false


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

This PR allows a specific version of the egeria-jupyer-notebooks repository to be checked
out when the jupyter container is launched. this is defined in the yaml for the jupyter deployment.

A tag or branch can be specified by setting 'jupyter.gitTagForNotebooks'. If no value is specified, the the default branch (main) will be used.

In the chart values, the default value for this parm is set to: "main"

So for example, if we wanted to use the 'v313test' tag we'd deploy the chart with:
```
helm install lab odpi-egeria-lab --set jupyter.tokenPlain='s3cr3t!' --set jupyter.gitTagForNotebooks=v313test --set strimzi.enabled=false --devel
```

* Note this depends on https://github.com/odpi/egeria-jupyter-notebooks/actions/runs/3446111657/jobs/5750615410
* This PR also fixes #177
* The jupyter  image has increased in size (+200MB) -- see https://cloud.redhat.com/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id for some of the hoops needed to get jupyter working well in openshift. as that article asserts, we are nearing the end of where we can customize the image - beyond this it needs recreating from scratch. This will not be done at this point
* The new parm should be added to the egeria docs

