### PR TITLE
#216 Fix security context to work across OpenShift, Azure, Rancher

### DIFF
--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-base
 description: Egeria simple deployment (platform, react UI)
 apiVersion: v2
-version: 3.13.1
+version: 3.13.2
 appVersion: "3.13"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-base/templates/kafka-cluster.yaml
+++ b/charts/egeria-base/templates/kafka-cluster.yaml
@@ -32,20 +32,12 @@ spec:
           type: persistent-claim
           size: 5Gi
           deleteClaim: true
-    template:
-      pod:
-        securityContext:
-          {  }
   zookeeper:
     replicas: 1
     storage:
       type: persistent-claim
       size: 1Gi
       deleteClaim: true
-    template:
-      pod:
-        securityContext:
-          { }
   entityOperator:
     topicOperator:
       reconciliationIntervalSeconds: 20

--- a/charts/egeria-cts/Chart.yaml
+++ b/charts/egeria-cts/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-cts
 description: Egeria Conformance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.13.1
+version: 3.13.2
 appVersion: "3.13"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-cts/templates/kafka-cluster.yaml
+++ b/charts/egeria-cts/templates/kafka-cluster.yaml
@@ -32,20 +32,12 @@ spec:
           type: persistent-claim
           size: 5Gi
           deleteClaim: true
-    template:
-      pod:
-        securityContext:
-          { }
   zookeeper:
     replicas: 1
     storage:
       type: persistent-claim
       size: 1Gi
       deleteClaim: true
-    template:
-      pod:
-        securityContext:
-          { }
   entityOperator:
     topicOperator:
       reconciliationIntervalSeconds: 20

--- a/charts/egeria-pts/Chart.yaml
+++ b/charts/egeria-pts/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-pts
 description: Egeria Performance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.13.1
+version: 3.13.2
 appVersion: "3.13"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-pts/templates/kafka-cluster.yaml
+++ b/charts/egeria-pts/templates/kafka-cluster.yaml
@@ -32,20 +32,12 @@ spec:
           type: persistent-claim
           size: 5Gi
           deleteClaim: true
-    template:
-      pod:
-        securityContext:
-          { }
   zookeeper:
     replicas: 1
     storage:
       type: persistent-claim
       size: 1Gi
       deleteClaim: true
-    template:
-      pod:
-        securityContext:
-          { }
   entityOperator:
     topicOperator:
       reconciliationIntervalSeconds: 20

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v2
-version: 3.13.2
+version: 3.13.3
 appVersion: "3.13"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/templates/_helpers.tpl
+++ b/charts/odpi-egeria-lab/templates/_helpers.tpl
@@ -47,8 +47,3 @@ Create the name of the service account to use
 {{- define "egeria.security" -}}
 serviceAccountName: {{ template "mychart.serviceAccountName" . }}
 {{- end }}
-
-{{- define "egeria.platformscc" -}}
-securityContext:
-  { }
-{{- end }}

--- a/charts/odpi-egeria-lab/templates/egeria-core.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-core.yaml
@@ -123,7 +123,6 @@ spec:
               name: egeria-connector-volume
               readOnly: true
       restartPolicy: Always
-      {{- include "egeria.platformscc" . | nindent 6 }}
   {{ if .Values.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:

--- a/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
@@ -123,7 +123,6 @@ spec:
               name: egeria-connector-volume
               readOnly: true
       restartPolicy: Always
-      {{- include "egeria.platformscc" . | nindent 6 }}
   {{ if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/odpi-egeria-lab/templates/egeria-dev.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-dev.yaml
@@ -125,7 +125,6 @@ spec:
               name: egeria-connector-volume
               readOnly: true
       restartPolicy: Always
-      {{- include "egeria.platformscc" . | nindent 6 }}
   {{ if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/odpi-egeria-lab/templates/egeria-factory.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-factory.yaml
@@ -124,7 +124,6 @@ spec:
               name: egeria-connector-volume
               readOnly: true
       restartPolicy: Always
-      {{- include "egeria.platformscc" . | nindent 6 }}
   {{ if .Values.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:

--- a/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
+++ b/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
@@ -32,20 +32,12 @@ spec:
           type: persistent-claim
           size: 5Gi
           deleteClaim: true
-    template:
-      pod:
-        securityContext:
-          {  }
   zookeeper:
     replicas: 1
     storage:
       type: persistent-claim
       size: 1Gi
       deleteClaim: true
-    template:
-      pod:
-        securityContext:
-          { }
   entityOperator:
     topicOperator:
       reconciliationIntervalSeconds: 20


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

* Fixes all charts to work on OpenShift 4 + Azure Kubernetes Service + Rancher desktop

This PR removes the explicit empty security context (it does not allow for configuration, at least for egeria pods). This had previously been added when addressing issues with openshift which turned out to be due to using the default namespace (which does not work) and were not needed (though harmless) for other namespaces, even using the restricted scc

These additions broke deployment in AKS and have been removed.

Only tested in a simple single node, default AKS cluster, alongside OpenShift 4.11 in IBMCloud & Rancher desktop.

Fixes #216 