### PR TITLE
prerelease.1, updates to kafka v3.3.1

### DIFF
--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-base
 description: Egeria simple deployment (platform, react UI)
 apiVersion: v2
-version: 3.14.0-prerelease.0
+version: 3.14.0-prerelease.1
 appVersion: "3.14"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-base/templates/kafka-cluster.yaml
+++ b/charts/egeria-base/templates/kafka-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Release.Name }}-strimzi
 spec:
   kafka:
-    version: 3.2.3
+    version: 3.3.1
     replicas: 1
     listeners:
       - name: plain

--- a/charts/egeria-cts/Chart.yaml
+++ b/charts/egeria-cts/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-cts
 description: Egeria Conformance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.14.0-prerelease.0
+version: 3.14.0-prerelease.1
 appVersion: "3.14"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-cts/templates/kafka-cluster.yaml
+++ b/charts/egeria-cts/templates/kafka-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Release.Name }}-strimzi
 spec:
   kafka:
-    version: 3.2.3
+    version: 3.3.1
     replicas: 1
     listeners:
       - name: plain

--- a/charts/egeria-pts/Chart.yaml
+++ b/charts/egeria-pts/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-pts
 description: Egeria Performance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 3.14.0-prerelease.0
+version: 3.14.0-prerelease.1
 appVersion: "3.14"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-pts/templates/kafka-cluster.yaml
+++ b/charts/egeria-pts/templates/kafka-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Release.Name }}-strimzi
 spec:
   kafka:
-    version: 3.2.3
+    version: 3.3.1
     replicas: 1
     listeners:
       - name: plain

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v2
-version: 3.14.0-prerelease.0
+version: 3.14.0-prerelease.1
 appVersion: "3.14"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
+++ b/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Release.Name }}-strimzi
 spec:
   kafka:
-    version: 3.2.3
+    version: 3.3.1
     replicas: 1
     listeners:
       - name: plain

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -57,7 +57,7 @@ jupyter:
   # tokenPlain:
   # ----
   # Git tag to checkout in the egeria-jupyter repo
-  gitTagForNotebooks: "main"
+  gitTagForNotebooks: "V314"
 
 debug:
   egeriaJVM: false


### PR DESCRIPTION
- Update strimzi kafka version to 3.3.1 (Tested using odpi-egeria-lab chart)
- Fix tag for jupyter notebooks to V314