### PR TITLE
Allow cpu/ram resources to be configured, plus jvm settings

### DIFF
--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,8 +4,8 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v2
-version: 3.15.0
-appVersion: "3.15"
+version: 4.0.0-prerelease.0
+appVersion: "4.0"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
   - odpi, egeria, lab, jupyter, notebook
@@ -19,6 +19,6 @@ maintainers:
     email: nigel.l.jones+git@gmail.com
 dependencies:
   - name: strimzi-kafka-operator
-    version: 0.33.0
+    version: 0.33.2
     repository: https://strimzi.io/charts/
     condition: strimzi.enabled

--- a/charts/odpi-egeria-lab/templates/egeria-core.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-core.yaml
@@ -104,6 +104,8 @@ spec:
               value: "/deployments/server/extralib,/deployments/server/lib"
             - name: JAVA_OPTS_APPEND
               value: {{ .Values.egeria.core.jvmopts | quote }}
+            - name: JAVA_MAX_MEM_RATIO
+              value: "80"
           ports:
             - containerPort: 9443
           {{ if .Values.debug.egeriaJVM }}

--- a/charts/odpi-egeria-lab/templates/egeria-core.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-core.yaml
@@ -102,6 +102,8 @@ spec:
             {{ end }}
             - name: "LOADER_PATH"
               value: "/deployments/server/extralib,/deployments/server/lib"
+            - name: JAVA_OPTS_APPEND
+              value: {{ .Values.egeria.core.jvmopts | quote }}
           ports:
             - containerPort: 9443
           {{ if .Values.debug.egeriaJVM }}
@@ -113,7 +115,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 6
-          resources: {}
+          resources: {{ toYaml .Values.egeria.core.resources | nindent 12 }}
           volumeMounts:
           {{ if .Values.persistence.enabled }}
             - mountPath: "/deployments/data"

--- a/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
@@ -102,6 +102,8 @@ spec:
             {{ end }}
             - name: "LOADER_PATH"
               value: "/deployments/server/extralib,/deployments/server/lib"
+            - name: JAVA_OPTS_APPEND
+              value: {{ .Values.egeria.datalake.jvmopts | quote }}
           ports:
             - containerPort: 9443
           {{ if .Values.debug.egeriaJVM }}
@@ -113,7 +115,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 6
-          resources: {}
+          resources: {{ toYaml .Values.egeria.datalake.resources | nindent 12 }}
           volumeMounts:
           {{ if .Values.persistence.enabled }}
             - mountPath: "/deployments/data"

--- a/charts/odpi-egeria-lab/templates/egeria-dev.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-dev.yaml
@@ -104,6 +104,8 @@ spec:
             {{ end }}
             - name: "LOADER_PATH"
               value: "/deployments/server/extralib,/deployments/server/lib"
+            - name: JAVA_OPTS_APPEND
+              value: {{ .Values.egeria.dev.jvmopts | quote }}
           ports:
             - containerPort: 9443
             {{ if .Values.debug.egeriaJVM }}
@@ -115,7 +117,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 6
-          resources: {}
+          resources: {{ toYaml .Values.egeria.dev.resources | nindent 12 }}
           volumeMounts:
           {{ if .Values.persistence.enabled }}
             - mountPath: "/deployments/data"

--- a/charts/odpi-egeria-lab/templates/egeria-factory.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-factory.yaml
@@ -103,6 +103,8 @@ spec:
             {{ end }}
             - name: "LOADER_PATH"
               value: "/deployments/server/extralib,/deployments/server/lib"
+            - name: JAVA_OPTS_APPEND
+              value: {{ .Values.egeria.factory.jvmopts | quote }}
           ports:
             - containerPort: 9443
             {{ if .Values.debug.egeriaJVM }}
@@ -114,7 +116,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 6
-          resources: {}
+          resources: {{ toYaml .Values.egeria.factory.resources | nindent 12 }}
           volumeMounts:
           {{ if .Values.persistence.enabled }}
             - mountPath: "/deployments/data"

--- a/charts/odpi-egeria-lab/templates/egeria-nginx.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-nginx.yaml
@@ -108,7 +108,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 6
-          resources: {}
+          resources: {{ toYaml .Values.nginx.resources | nindent 12 }}
           env:
             - name: UI_STATIC
               value: http://{{ .Release.Name }}-uistatic:8080
@@ -116,6 +116,8 @@ spec:
               value: https://{{ .Release.Name }}-ui:8443
             - name: NGINX_SERVER_NAME
               value: {{ .Release.Name}}-nginx
+            - name: JAVA_OPTS_APPEND
+              value: {{ .Values.nginx.jvmopts | quote }}
           volumeMounts:
             - name: template-vol
               mountPath: /etc/nginx/templates

--- a/charts/odpi-egeria-lab/templates/egeria-presentation.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-presentation.yaml
@@ -70,12 +70,14 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 6
-          resources: {}
+          resources: {{ toYaml .Values.egeria.presentation.resources | nindent 12 }}
           env:
             - name: EGERIA_PRESENTATIONSERVER_SERVER_coco
               value: "{\"remoteServerName\":\"cocoView1\",\"remoteURL\":\"https://{{ .Release.Name }}-datalake:9443\"}"
             - name: EGERIA_PRESENTATIONSERVER_REJECTUNAUTHORIZED_FOR_OMAG
               value: "false"
+            - name: JAVA_OPTS_APPEND
+              value: {{ .Values.egeria.presentation.jvmopts | quote }}
       restartPolicy: Always
 
 ...

--- a/charts/odpi-egeria-lab/templates/egeria-ui.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-ui.yaml
@@ -82,7 +82,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 6
-          resources: {}
+          resources: {{ toYaml .Values.egeria.ui.resources | nindent 12 }}
           env:
             - name: "OMAS_SERVER_NAME"
               value: "cocoMDS1"
@@ -100,6 +100,8 @@ spec:
             {{ end }}
             - name: "JAVA_APP_JAR"
               value: "user-interface/ui-chassis-spring-{{ .Values.egeria.version}}.jar"
+            - name: JAVA_OPTS_APPEND
+              value: {{ .Values.egeria.ui.jvmopts | quote }}
       restartPolicy: Always
 
 ...

--- a/charts/odpi-egeria-lab/templates/egeria-uistatic.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-uistatic.yaml
@@ -104,10 +104,13 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 6
-          resources: {}
+          resources: {{ toYaml .Values.egeria.uistatic.resources | nindent 12 }}
           #env:
           #  - name: EGERIA_PRESENTATIONSERVER_SERVER_coco
           #    value: "{\"remoteServerName\":\"cocoView1\",\"remoteURL\":\"https://{{ .Release.Name }}-datalake:9443\"}"
+          env:
+            - name: JAVA_OPTS_APPEND
+              value: {{ .Values.egeria.uistatic.jvmopts | quote }}
           volumeMounts:
             - name: template-vol
               mountPath: /etc/nginx/templates

--- a/charts/odpi-egeria-lab/templates/jupyter.yaml
+++ b/charts/odpi-egeria-lab/templates/jupyter.yaml
@@ -107,8 +107,6 @@ spec:
             # Contains the truststore from Egeria self-signed certs, in .pem format
             #- name: REQUESTS_CA_BUNDLE
             #  value: "/home/jovyan/ssl/truststore.pem"
-            - name: JAVA_OPTS_APPEND
-              value: {{ .Values.jupyter.jvmopts | quote }}
           ports:
             - containerPort: 8888
           readinessProbe:

--- a/charts/odpi-egeria-lab/templates/jupyter.yaml
+++ b/charts/odpi-egeria-lab/templates/jupyter.yaml
@@ -107,6 +107,8 @@ spec:
             # Contains the truststore from Egeria self-signed certs, in .pem format
             #- name: REQUESTS_CA_BUNDLE
             #  value: "/home/jovyan/ssl/truststore.pem"
+            - name: JAVA_OPTS_APPEND
+              value: {{ .Values.jupyter.jvmopts | quote }}
           ports:
             - containerPort: 8888
           readinessProbe:
@@ -122,7 +124,7 @@ spec:
               mountPath: "/usr/local/bin/before-notebook.d"
             #- name: ssl-vol
             #  mountPath: "/home/jovyan/ssl"
-          resources: {}
+          resources: {{ toYaml .Values.jupyter.resources | nindent 12 }}
       volumes:
         - name: notebook-scripts-vol
           configMap:

--- a/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
+++ b/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   kafka:
     version: 3.3.2
-    replicas: 1
+    replicas: {{ .Values.kafka.replicas }}
     listeners:
       - name: plain
         port: 9092
@@ -32,12 +32,14 @@ spec:
           type: persistent-claim
           size: 5Gi
           deleteClaim: true
+    resources: {{ .Values.kafka.resources | toYaml | nindent 6 }}}
   zookeeper:
-    replicas: 1
+    replicas: {{ .Values.zookeeper.replicas }}
     storage:
       type: persistent-claim
       size: 1Gi
       deleteClaim: true
+    resources: {{ .Values.zookeeper.resources | toYaml | nindent 6 }}}
   entityOperator:
     topicOperator:
       reconciliationIntervalSeconds: 20

--- a/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
+++ b/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Release.Name }}-strimzi
 spec:
   kafka:
-    version: 3.3.2
+    version: 3.4.0
     replicas: {{ .Values.kafka.replicas }}
     listeners:
       - name: plain

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -38,6 +38,82 @@ egeria:
   # Set to 'true' to deploy the Egeria UI, but note the configuration may not work properly
   egeriaui: true
 
+  # Container specific -- including fine grained control of memory limits
+  # Note that by default 'jvmopts' is not set as this will be set automatically when using the Egeria base container, based off the memory limits
+  core:
+    #jvmopts: "-Xms500m -Xmx1024m"
+    resources:
+      limits:
+        cpu: 2000m
+        memory: 2Gi
+      requests:
+        cpu: 250m
+        memory: 1Gi
+  datalake:
+    #jvmopts: "-Xms500m -Xmx1024m"
+    resources:
+      limits:
+        cpu: 2000m
+        memory: 2Gi
+      requests:
+        cpu: 250m
+        memory: 1Gi
+  dev:
+    #jvmopts: "-Xms500m -Xmx1024m"
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+      requests:
+        cpu: 500m
+        memory: 500Mi
+  factory:
+    #jvmopts: "-Xms250m -Xmx512m"
+    resources:
+      limits:
+        cpu: 250m
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 768Mi
+  ui:
+    #jvmopts: "-Xms512m -Xmx1024m"
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+      requests:
+        cpu: 200m
+        memory: 768Mi
+  uistatic:
+    #jvmopts: "-Xms128m -Xmx512m"
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+  presentation:
+    #jvmopts: "-Xms250m -Xmx512m"
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 2Gi
+      requests:
+        cpu: 100m
+        memory: 1Gi
+
+nginx:
+  #jvmopts: "-Xms64m -Xmx256m"
+  resources:
+    limits:
+      cpu: 500m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
 # Additional connectors/libraries to be made available in egeria server chassis containers
 # This is just an example. You can have a list of connectors
 #extralibs:
@@ -58,7 +134,35 @@ jupyter:
   # ----
   # Git tag to checkout in the egeria-jupyter repo
   gitTagForNotebooks: "v315"
+  jvmopts: "-Xms500m -Xmx1024m"
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+    requests:
+      cpu: 100m
+      memory: 1Gi
 
+# Strimzi is used to setup an operator which will manage the custom resource we define.
+# These entries are used to define that custom resource
+kafka:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 2000m
+      memory: 1Gi
+    requests:
+      cpu: 250m
+      memory: 500Mi
+zookeeper:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 500m
+      memory: 750Mi
+    requests:
+      cpu: 100m
+      memory: 350Mi
 debug:
   egeriaJVM: false
 
@@ -137,3 +241,5 @@ persistence:
 # installed on the cluster by an admin, or a prior install
 strimzi:
   enabled: true
+
+

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -31,7 +31,7 @@ service:
 egeria:
   #logging: OFF
   development: true
-  version: "3.15"
+  version: "4.0-SNAPSHOT"
   #repositoryType: "local-graph-repository"
   repositoryType: "in-memory-repository"
   # See https://github.com/odpi/egeria-charts/issues/56 for status of the Egeria UI (polymer) in this environment
@@ -40,79 +40,87 @@ egeria:
 
   # Container specific -- including fine grained control of memory limits
   # Note that by default 'jvmopts' is not set as this will be set automatically when using the Egeria base container, based off the memory limits
+  # This is done by JAVA_MAX_MEM_RATIO=80 in the templates
+  # Best practice is to not overcommit, especially memory, so limits-requests set same. In some cases the request can be set lower
   core:
     #jvmopts: "-Xms500m -Xmx1024m"
+    #jvmopts: "-XX:MinRAMPercentage=10 -XX:MaxRAMPercentage=80"
     resources:
       limits:
         cpu: 2000m
         memory: 2Gi
       requests:
-        cpu: 250m
+        cpu: 2000m
         memory: 1Gi
   datalake:
     #jvmopts: "-Xms500m -Xmx1024m"
+    #jvmopts: "-XX:MinRAMPercentage=10 -XX:MaxRAMPercentage=80"
     resources:
       limits:
         cpu: 2000m
         memory: 2Gi
       requests:
         cpu: 250m
-        memory: 1Gi
+        memory: 2Gi
   dev:
     #jvmopts: "-Xms500m -Xmx1024m"
+    #jvmopts: "-XX:MinRAMPercentage=40 -XX:MaxRAMPercentage=80"
     resources:
       limits:
         cpu: 1000m
         memory: 1Gi
       requests:
         cpu: 500m
-        memory: 500Mi
+        memory: 1Gi
   factory:
     #jvmopts: "-Xms250m -Xmx512m"
+    #jvmopts: "-XX:MinRAMPercentage=40 -XX:MaxRAMPercentage=80"
     resources:
       limits:
         cpu: 250m
         memory: 1Gi
       requests:
         cpu: 100m
-        memory: 768Mi
+        memory: 1Gi
   ui:
     #jvmopts: "-Xms512m -Xmx1024m"
+    #jvmopts: "-XX:MinRAMPercentage=40 -XX:MaxRAMPercentage=80"
     resources:
       limits:
         cpu: 1000m
         memory: 1Gi
       requests:
         cpu: 200m
-        memory: 768Mi
+        memory: 1Gi
   uistatic:
     #jvmopts: "-Xms128m -Xmx512m"
+    #jvmopts: "-XX:MinRAMPercentage=40 -XX:MaxRAMPercentage=80"
     resources:
       limits:
         cpu: 500m
         memory: 256Mi
       requests:
         cpu: 100m
-        memory: 128Mi
+        memory: 256Mi
   presentation:
     #jvmopts: "-Xms250m -Xmx512m"
+    #jvmopts: "-XX:MinRAMPercentage=25 -XX:MaxRAMPercentage=80"
     resources:
       limits:
         cpu: 1000m
-        memory: 2Gi
+        memory: 768Mi
       requests:
         cpu: 100m
-        memory: 1Gi
+        memory: 768Mi
 
 nginx:
-  #jvmopts: "-Xms64m -Xmx256m"
   resources:
     limits:
       cpu: 500m
       memory: 256Mi
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 256Mi
 
 # Additional connectors/libraries to be made available in egeria server chassis containers
 # This is just an example. You can have a list of connectors
@@ -134,14 +142,13 @@ jupyter:
   # ----
   # Git tag to checkout in the egeria-jupyter repo
   gitTagForNotebooks: "v315"
-  jvmopts: "-Xms500m -Xmx1024m"
   resources:
     limits:
       cpu: 1000m
       memory: 2Gi
     requests:
       cpu: 100m
-      memory: 1Gi
+      memory: 2Gi
 
 # Strimzi is used to setup an operator which will manage the custom resource we define.
 # These entries are used to define that custom resource
@@ -153,7 +160,7 @@ kafka:
       memory: 1Gi
     requests:
       cpu: 250m
-      memory: 500Mi
+      memory: 1Gi
 zookeeper:
   replicas: 1
   resources:
@@ -162,7 +169,7 @@ zookeeper:
       memory: 750Mi
     requests:
       cpu: 100m
-      memory: 350Mi
+      memory: 750Mi
 debug:
   egeriaJVM: false
 


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

* Adds support for specifying resources (cpu, memory & limit, request) for all containers independently - except for strimzi operator which is left to it's defaults
* Initial sizes are a guess and will be validated after further experimentation
* Default max heap is set to 80% of the allocated container request (by the UBI9 image we use)
* Best practice is no overcommit, so request==limit

More docs to follow in later PR
cc: @dwolfson 