### PR TITLE
Revert to defaults for resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ helm show values egeria/odpi-egeria-lab
 
 See also the https://github.com/odpi/egeria-k8s-operator repository for development of an Operator for Egeria.
 
+## Useful tools
+
+* [K9s](https://k9scli.io) is very useful. It provides a terminal UI to view your pods, and provides a number of useful features such as tailing logs, exec into a pod, and more. It is a great tool for debugging issues with your pods. On macOS using homebrew: `brew install k9s`
 
 ----
 License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v2
-version: 4.0.0-prerelease.6
+version: 4.0.0-prerelease.7
 appVersion: "4.0"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/templates/egeria-core.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-core.yaml
@@ -103,10 +103,10 @@ spec:
             {{ end }}
             - name: "LOADER_PATH"
               value: "/deployments/server/extralib,/deployments/server/lib"
-            - name: JAVA_OPTS_APPEND
+            {{ if .Values.egeria.core.jvmopts }}
+            - name: JAVA_OPTS
               value: {{ .Values.egeria.core.jvmopts | quote }}
-            - name: JAVA_MAX_MEM_RATIO
-              value: "80"
+            {{ end }}
           ports:
             - containerPort: 9443
           {{ if .Values.debug.egeriaJVM }}

--- a/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
@@ -103,8 +103,10 @@ spec:
             {{ end }}
             - name: "LOADER_PATH"
               value: "/deployments/server/extralib,/deployments/server/lib"
-            - name: JAVA_OPTS_APPEND
+            {{ if .Values.egeria.datalake.jvmopts }}
+            - name: JAVA_OPTS
               value: {{ .Values.egeria.datalake.jvmopts | quote }}
+            {{ end }}
           ports:
             - containerPort: 9443
           {{ if .Values.debug.egeriaJVM }}

--- a/charts/odpi-egeria-lab/templates/egeria-dev.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-dev.yaml
@@ -104,8 +104,10 @@ spec:
             {{ end }}
             - name: "LOADER_PATH"
               value: "/deployments/server/extralib,/deployments/server/lib"
-            - name: JAVA_OPTS_APPEND
+            {{ if .Values.egeria.dev.jvmopts }}
+            - name: JAVA_OPTS
               value: {{ .Values.egeria.dev.jvmopts | quote }}
+            {{ end }}
           ports:
             - containerPort: 9443
             {{ if .Values.debug.egeriaJVM }}

--- a/charts/odpi-egeria-lab/templates/egeria-factory.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-factory.yaml
@@ -103,8 +103,10 @@ spec:
             {{ end }}
             - name: "LOADER_PATH"
               value: "/deployments/server/extralib,/deployments/server/lib"
-            - name: JAVA_OPTS_APPEND
-              value: {{ .Values.egeria.factory.jvmopts | quote }}
+            {{ if .Values.egeria.core.jvmopts }}
+            - name: JAVA_OPTS
+              value: {{ .Values.egeria.core.jvmopts | quote }}
+            {{ end }}
           ports:
             - containerPort: 9443
             {{ if .Values.debug.egeriaJVM }}

--- a/charts/odpi-egeria-lab/templates/egeria-ui.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-ui.yaml
@@ -101,8 +101,10 @@ spec:
             {{ end }}
             - name: "JAVA_APP_JAR"
               value: "user-interface/ui-chassis-spring-{{ .Values.egeria.version}}.jar"
-            - name: JAVA_OPTS_APPEND
+            {{ if .Values.egeria.ui.jvmopts }}
+            - name: JAVA_OPTS
               value: {{ .Values.egeria.ui.jvmopts | quote }}
+            {{ end }}
       restartPolicy: Always
 
 ...

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -92,7 +92,7 @@ kafka:
   replicas: 3
   resources: {}
 zookeeper:
-  replicas: 1
+  replicas: 2
   resources: {}
 debug:
   egeriaJVM: false

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -39,94 +39,30 @@ egeria:
   egeriaui: true
 
   # Container specific -- including fine grained control of memory limits
-  # Note that by default 'jvmopts' is not set as this will be set automatically when using the Egeria base container, based off the memory limits
-  # This is done by JAVA_MAX_MEM_RATIO=80 in the templates
   # Best practice is to not overcommit, especially memory, so limits-requests set same. In some cases the request can be set lower
+  # Overriding JVM options is only supported for our egeria platforms (including ui-chassis)
+  # K8s implementations vary. Setting the max ram by percentage is better, but is very platform dependent - depending on the container
+  # environment being used - for example cgroups vs cgroups2. Therefore the default sets explicit values, so set in both places
+  # and make the max heap approx 80% of the memory limit
   core:
-    #jvmopts: "-Xms500m -Xmx1024m"
-    #jvmopts: "-XX:MinRAMPercentage=10 -XX:MaxRAMPercentage=80"
-    jvmopts: "-Dmanagement.endpoints.web.exposure.include=*"
-    resources:
-      limits:
-        cpu: 2000m
-        memory: 1000Mi
-      requests:
-        cpu: 200m
-        memory: 1000Mi
+    #jvmopts:
+    resources: {}
   datalake:
-    #jvmopts: "-Xms500m -Xmx1024m"
-    #jvmopts: "-XX:MinRAMPercentage=10 -XX:MaxRAMPercentage=80"
-    jvmopts: "-Dmanagement.endpoints.web.exposure.include=*"
-    resources:
-      limits:
-        cpu: 2000m
-        memory: 1000Mi
-      requests:
-        cpu: 200m
-        memory: 1000Mi
+    #jvmopts:
+    resources: {}
   dev:
-    #jvmopts: "-Xms500m -Xmx1024m"
-    #jvmopts: "-XX:MinRAMPercentage=40 -XX:MaxRAMPercentage=80"
-    jvmopts: "-Dmanagement.endpoints.web.exposure.include=*"
-    resources:
-      limits:
-        cpu: 2000m
-        memory: 1000Mi
-      requests:
-        cpu: 200m
-        memory: 1000Mi
+    #jvmopts:
+    resources: {}
   factory:
-    #jvmopts: "-Xms250m -Xmx512m"
-    #jvmopts: "-XX:MinRAMPercentage=40 -XX:MaxRAMPercentage=80"
-    jvmopts: "-Dmanagement.endpoints.web.exposure.include=*"
-    resources:
-      limits:
-        cpu: 100m
-        memory: 768Mi
-      requests:
-        cpu: 10m
-        memory: 768Mi
+    #jvmopts:
+    resources: {}
   ui:
-    #jvmopts: "-Xms512m -Xmx1024m"
-    #jvmopts: "-XX:MinRAMPercentage=40 -XX:MaxRAMPercentage=80"
-    jvmopts: "-XX:+HeapDumpOnOutOfMemoryError"
-    resources:
-      limits:
-        cpu: 1000m
-        memory: 500Mi
-      requests:
-        cpu: 50m
-        memory: 500Mi
-  uistatic:
-    #jvmopts: "-Xms128m -Xmx512m"
-    #jvmopts: "-XX:MinRAMPercentage=40 -XX:MaxRAMPercentage=80"
-    resources:
-      limits:
-        cpu: 100m
-        memory: 160Mi
-      requests:
-        cpu: 10m
-        memory: 160Mi
+    resources: {}
+  uistatic: {}
   presentation:
-    #jvmopts: "-Xms250m -Xmx512m"
-    #jvmopts: "-XX:MinRAMPercentage=25 -XX:MaxRAMPercentage=80"
-    jvmopts: "-XX:+HeapDumpOnOutOfMemoryError"
-    resources:
-      limits:
-        cpu: 1000m
-        memory: 768Mi
-      requests:
-        cpu: 50m
-        memory: 768Mi
-
+    resources: {}
 nginx:
-  resources:
-    limits:
-      cpu: 100m
-      memory: 160Mi
-    requests:
-      cpu: 10m
-      memory: 160Mi
+  resources: {}
 
 # Additional connectors/libraries to be made available in egeria server chassis containers
 # This is just an example. You can have a list of connectors
@@ -148,34 +84,16 @@ jupyter:
   # ----
   # Git tag to checkout in the egeria-jupyter repo
   gitTagForNotebooks: "main"
-  resources:
-    limits:
-      cpu: 1000m
-      memory: 1Gi
-    requests:
-      cpu: 100m
-      memory: 1Gi
+  resources: {}
 
 # Strimzi is used to setup an operator which will manage the custom resource we define.
 # These entries are used to define that custom resource
 kafka:
-  replicas: 1
-  resources:
-    limits:
-      cpu: 1000m
-      memory: 1Gi
-    requests:
-      cpu: 250m
-      memory: 1Gi
+  replicas: 3
+  resources: {}
 zookeeper:
   replicas: 1
-  resources:
-    limits:
-      cpu: 500m
-      memory: 750Mi
-    requests:
-      cpu: 100m
-      memory: 750Mi
+  resources: {}
 debug:
   egeriaJVM: false
 

--- a/config/values/lab-jvmoptsmemdebug.yaml
+++ b/config/values/lab-jvmoptsmemdebug.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
+
+# Example to enable tracing of memory usage in the container
+# We use the default garbage collector (G1), aim for a 80% ram usage, and enable spring monitoring
+
+egeria:
+  core:
+    jvmopts: "-Xlog:os+container=trace -XX:+ExitOnOutOfMemoryError -XX:+UseG1GC -Xlog:gc -Xms512m -Xmx1024m -XX:MaxRAM=1800m-Dmanagement.endpoints.web.exposure.include=*"
+  datalake:
+    jvmopts: "-Xlog:os+container=trace -XX:+ExitOnOutOfMemoryError -XX:+UseG1GC -Xlog:gc -Xms512m -Xmx1024m -XX:MaxRAM=1800m-Dmanagement.endpoints.web.exposure.include=*"
+  dev:
+    jvmopts: "-Xlog:os+container=trace -XX:+ExitOnOutOfMemoryError -XX:+UseG1GC -Xlog:gc -Xms512m -Xmx1024m -XX:MaxRAM=1800m-Dmanagement.endpoints.web.exposure.include=*"
+  factory:
+    jvmopts: "-Xlog:os+container=trace -XX:+ExitOnOutOfMemoryError -XX:+UseG1GC -Xlog:gc -Xms512m -Xmx1024m -XX:MaxRAM=1800m-Dmanagement.endpoints.web.exposure.include=*"
+

--- a/config/values/lab-nodeport.yaml
+++ b/config/values/lab-nodeport.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
+
+# Enables default nodeports
+service:
+  type: NodePort


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Investigation continues in #235

For now, resources will be unlimited by default, so subject to whatever the container environment deems suitable.
JVM settings will also be reverted by default

Resource limits & jvm configuration can be applied using one of the sample fragments in config/values

Increment version