### PR TITLE
#119 add support for storage class

### DIFF
--- a/charts/egeria-base/Chart.yaml
+++ b/charts/egeria-base/Chart.yaml
@@ -4,7 +4,7 @@
 name: egeria-base
 description: A Helm chart for Egeria simple platform deployment
 apiVersion: v2
-version: 4.0-prerelease.2
+version: 4.0-prerelease.3
 appVersion: "4.0"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/egeria-base/templates/kafka-cluster.yaml
+++ b/charts/egeria-base/templates/kafka-cluster.yaml
@@ -39,18 +39,21 @@ spec:
       initialDelaySeconds: 15
       timeoutSeconds: 5
     storage:
-      type: jbod
-      volumes:
-        - id: 0
-          type: persistent-claim
-          size: 5Gi
-          deleteClaim: true
+      type: persistent-claim
+      size: 5Gi
+      deleteClaim: true
+      {{- if .Values.storageClassName }}
+      class: {{ .Values.storageClassName }}
+      {{- end }}
   zookeeper:
     replicas: 1
     storage:
       type: persistent-claim
       size: 1Gi
       deleteClaim: true
+      {{- if .Values.storageClassName }}
+      class: {{ .Values.storageClassName }}
+      {{- end }}
   entityOperator:
     topicOperator:
       reconciliationIntervalSeconds: 5

--- a/charts/egeria-base/templates/platform.yaml
+++ b/charts/egeria-base/templates/platform.yaml
@@ -194,8 +194,8 @@ spec:
       resources:
         requests:
           storage: {{ .Values.egeria.storageSize}}
-      {{ if .Values.egeria.storageClass }}
-      storageClassName: {{ .Values.egeria.storageClass }}
-      {{ end }}
+      {{- if .Values.storageClassName }}
+      storageClassName: {{ .Values.storageClassName }}
+      {{- end }}
   {{ end }}
 ...

--- a/charts/egeria-base/values.yaml
+++ b/charts/egeria-base/values.yaml
@@ -64,8 +64,6 @@ egeria:
   viewOrg: org
   # Cohort name
   cohort: mds
-  # Set to override the k8s storage class for persistent volume claim
-  storageClass:
   # Default to 8GB
   storageSize: 8Gi
   # Whether a default configuration is performed or not. Note that the environment for
@@ -217,3 +215,6 @@ lineage:
 # These are used to override name of the egeria deployment in the helpers template
 fullnameOverride:
 nameOverride:
+
+# Set to override the k8s storage class for persistent volume claim
+storageClassName:

--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v2
-version: 4.0.0-prerelease.9
+version: 4.0.0-prerelease.10
 appVersion: "4.0"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:

--- a/charts/odpi-egeria-lab/templates/egeria-core.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-core.yaml
@@ -138,6 +138,8 @@ spec:
       resources:
         requests:
           storage: 8Gi
-      #storageClassName:
+      {{- if .Values.storageClassName }}
+      storageClassName: {{ .Values.storageClassName }}
+      {{- end }}
   {{ end }}
 ...

--- a/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-datalake.yaml
@@ -130,14 +130,16 @@ spec:
       restartPolicy: Always
   {{ if .Values.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
-        name: {{ .Release.Name }}-datalake-data
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 8Gi
-        #storageClassName:
+  - metadata:
+      name: {{ .Release.Name }}-datalake-data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 8Gi
+      {{- if .Values.storageClassName }}
+      storageClassName: {{ .Values.storageClassName }}
+      {{- end }}
   {{ end }}
 ...

--- a/charts/odpi-egeria-lab/templates/egeria-dev.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-dev.yaml
@@ -131,14 +131,16 @@ spec:
       restartPolicy: Always
   {{ if .Values.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
-        name: {{ .Release.Name }}-dev-data
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 8Gi
-        #storageClassName:
+  - metadata:
+      name: {{ .Release.Name }}-dev-data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 8Gi
+      {{- if .Values.storageClassName }}
+      storageClassName: {{ .Values.storageClassName }}
+      {{- end }}
   {{ end }}
 ...

--- a/charts/odpi-egeria-lab/templates/egeria-factory.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-factory.yaml
@@ -138,6 +138,8 @@ spec:
       resources:
         requests:
           storage: 8Gi
-      #storageClassName:
+      {{ if .Values.storageClassName }}
+      storageClassName: {{ .Values.storageClassName }}
+      {{ end }}
   {{ end }}
 ...

--- a/charts/odpi-egeria-lab/templates/jupyter.yaml
+++ b/charts/odpi-egeria-lab/templates/jupyter.yaml
@@ -151,7 +151,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.jupyter.storageSize | default "1Gi" }}
-{{ if .Values.egeria.storageClass }}
-  storageClassName: {{ .Values.jupyter.StorageClass }}
-{{ end }}
+  {{- if .Values.storageClassName }}
+  storageClassName: {{ .Values.storageClassName }}
+  {{- end }}
 ...

--- a/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
+++ b/charts/odpi-egeria-lab/templates/kafka-cluster.yaml
@@ -26,12 +26,12 @@ spec:
       initialDelaySeconds: 15
       timeoutSeconds: 5
     storage:
-      type: jbod
-      volumes:
-        - id: 0
-          type: persistent-claim
-          size: 5Gi
-          deleteClaim: true
+      type: persistent-claim
+      size: 5Gi
+      deleteClaim: true
+      {{- if .Values.storageClassName }}
+      class: {{ .Values.storageClassName }}
+      {{- end }}
     resources: {{ .Values.kafka.resources | toYaml | nindent 6 }}
   zookeeper:
     replicas: {{ .Values.zookeeper.replicas }}
@@ -39,6 +39,9 @@ spec:
       type: persistent-claim
       size: 1Gi
       deleteClaim: true
+      {{- if .Values.storageClassName }}
+      class: {{ .Values.storageClassName }}
+      {{- end }}
     resources: {{ .Values.zookeeper.resources | toYaml | nindent 6 }}
   entityOperator:
     topicOperator:

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -166,6 +166,9 @@ serviceAccount:
 persistence:
   enabled: false
 
+# Storage Class - used for all allocations
+storageClassName:
+
 # Normally we install the strimzi operator as part of the Chart. However this requires admin permissions, and
 # will create cluster-scoped resources. Set to false to skip this when in a restricted environment, or needing multiple
 # installs of egeria charts in the same cluster. Requires the strimzi operator to be

--- a/config/values/lab-storageclass.yaml
+++ b/config/values/lab-storageclass.yaml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
+
+# Example of showing how to use a specific storageclass
+storageClassName: ibmc-vpc-block-general-purpose


### PR DESCRIPTION
* Adds support for specification of storage class
* Adds simple example

To use

```
helm install <blah blah> --set storageClassName='ibmc-vpc-block-general-purpose'
```
or

```
helm install <blah blah> -f config/values/lab-storageclass.yaml
```

The same storageclass will be used for all allocations. No other customizations are possible.

This has been implemented in base & lab charts