### PR TITLE
Increment prerelease version for lab chart to continue typo to ensure…

### DIFF
--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,7 +4,7 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v2
-version: 4.0.0-prerelease.13
+version: 4.0.0-prerelease.14gi
 appVersion: "4.0"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:


### PR DESCRIPTION
Earlier prereleases introduced a typo at the end of the version string 
13 < 11gi, so the latest lab prerelease chart does not install
This PR follows the prior, typo-introduced version label for this release
The 4.0 release will correct the naming.