### PR TITLE
Initial fixes for the new 4.1 release

### DIFF
--- a/charts/odpi-egeria-lab/templates/egeria-ui.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-ui.yaml
@@ -85,6 +85,8 @@ spec:
             failureThreshold: 6
           resources: {{ toYaml .Values.egeria.ui.resources | nindent 12 }}
           env:
+            - name: "SERVER_PORT"
+              value: "8443"
             - name: "OMAS_SERVER_NAME"
               value: "cocoMDS1"
             - name: "OMAS_SERVER_URL"

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -31,7 +31,7 @@ service:
 egeria:
   #logging: OFF
   development: true
-  version: "4.0"
+  version: "4.1-SNAPSHOT"
   #repositoryType: "local-graph-repository"
   repositoryType: "in-memory-repository"
   # See https://github.com/odpi/egeria-charts/issues/56 for status of the Egeria UI (polymer) in this environment


### PR DESCRIPTION
- Updated egeria version to 4.1-snapshot for preliminary testing
- Setting tomcat port to 8443 for ui-chassis-spring container to have it working with the lab chart again. This is due to latest changes where we have application.properties available externally in the spring loader path causing override of server.port property to 9443.