### PR TITLE
UI platform deployment fixes 

### DIFF
--- a/charts/odpi-egeria-lab/Chart.yaml
+++ b/charts/odpi-egeria-lab/Chart.yaml
@@ -4,8 +4,8 @@
 name: odpi-egeria-lab
 description: Egeria lab environment
 apiVersion: v2
-version: 4.1.0
-appVersion: "4.1"
+version: 4.2-prerelease.1
+appVersion: "4.2-SNAPSHOT"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
   - odpi, egeria, lab, jupyter, notebook

--- a/charts/odpi-egeria-lab/templates/egeria-ui.yaml
+++ b/charts/odpi-egeria-lab/templates/egeria-ui.yaml
@@ -85,8 +85,10 @@ spec:
             failureThreshold: 6
           resources: {{ toYaml .Values.egeria.ui.resources | nindent 12 }}
           env:
-            - name: "SERVER_PORT"
-              value: "8443"
+            - name: "SPRING_CONFIG_LOCATION"
+              value: "classpath:application.properties,classpath:application.yml"
+            - name: "LOADER_PATH"
+              value: "user-interface/lib"
             - name: "OMAS_SERVER_NAME"
               value: "cocoMDS1"
             - name: "OMAS_SERVER_URL"

--- a/charts/odpi-egeria-lab/values.yaml
+++ b/charts/odpi-egeria-lab/values.yaml
@@ -31,7 +31,7 @@ service:
 egeria:
   #logging: OFF
   development: true
-  version: "4.1"
+  version: "4.2-SNAPSHOT"
   #repositoryType: "local-graph-repository"
   repositoryType: "in-memory-repository"
   # See https://github.com/odpi/egeria-charts/issues/56 for status of the Egeria UI (polymer) in this environment


### PR DESCRIPTION
- Explicitly controlling spring configuration loading for ui-chassis-spring application
- loader.path set to empty location 
- Tested using docker and local Kubernetes

Addresses quick fix from previous release + #5918 - Best solution is still to have new dedicated docker image but this is more work since we need to reconsider the assembly structure.

I will explain the solution and the limitations in detail in #5918.