### PR TITLE
#7 add support for debugging to cts/pts

### DIFF
--- a/charts/egeria-cts/templates/platform.yaml
+++ b/charts/egeria-cts/templates/platform.yaml
@@ -88,8 +88,19 @@ spec:
           env:
             - name: "LOADER_PATH"
               value: "/opt/egeria/connectors,/deployments/server/lib"
+            {{ if .Values.debug.egeriaJVM }}
+              - name: JAVA_DEBUG
+                value:  "true"
+            {{ end }}
+            {{ if .Values.debug.jvmopts }}
+              - name: JAVA_OPTS
+                value: {{ .Values.egeria.core.jvmopts | quote }}
+            {{ end }}
           ports:
             - containerPort: 9443
+            {{ if .Values.debug.egeriaJVM }}
+            - containerPort: 5005
+            {{ end }}
           readinessProbe:
             tcpSocket:
               port: 9443

--- a/charts/egeria-cts/values.yaml
+++ b/charts/egeria-cts/values.yaml
@@ -88,3 +88,10 @@ image:
 # installed on the cluster by an admin, or a prior install
 strimzi:
   enabled: true
+
+# Debugging support
+debug:
+  # Set to true to attach enable the java agent for IDE debugging. Also makes port 5005 available from container
+  egeriaJVM: false
+  # Override jvm parameters - for example memory, logging etc
+  jvmOpts:

--- a/charts/egeria-pts/templates/pts.yaml
+++ b/charts/egeria-pts/templates/pts.yaml
@@ -58,8 +58,22 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-env
+          env:
+            - name: "LOADER_PATH"
+              value: "/opt/egeria/connectors,/deployments/server/lib"
+            {{ if .Values.debug.egeriaJVM }}
+            - name: JAVA_DEBUG
+              value:  "true"
+            {{ end }}
+            {{ if .Values.debug.jvmopts }}
+            - name: JAVA_OPTS
+              value: {{ .Values.egeria.core.jvmopts | quote }}
+            {{ end }}
           ports:
             - containerPort: 9443
+            {{ if .Values.debug.egeriaJVM }}
+            - containerPort: 5005
+            {{ end }}
           readinessProbe:
             tcpSocket:
               port: 9443

--- a/charts/egeria-pts/values.yaml
+++ b/charts/egeria-pts/values.yaml
@@ -95,3 +95,9 @@ image:
 strimzi:
   enabled: true
 
+# Debugging support
+debug:
+  # Set to true to attach enable the java agent for IDE debugging. Also makes port 5005 available from container
+  egeriaJVM: false
+  # Override jvm parameters - for example memory, logging etc
+  jvmOpts:


### PR DESCRIPTION
* Ability to set JVM_OPTS (additional jvm parameters ie for debugging) values: debug.jvmopts
* Ability to expose port 5005 & activate java agent for IDE debug values: debug.egeriaJVM