### PR TITLE
Add custom audit-log configuration for CTS chart

### DIFF
--- a/charts/egeria-cts/Chart.yaml
+++ b/charts/egeria-cts/Chart.yaml
@@ -4,8 +4,8 @@
 name: egeria-cts
 description: Egeria Conformance Test Suite deployment to Kubernetes
 apiVersion: v2
-version: 4.1.0
-appVersion: "4.1"
+version: 4.2-prerelease.1
+appVersion: "4.2-SNAPSHOT"
 icon: https://raw.githubusercontent.com/odpi/egeria/99016e77167fa30dcfade809b061358a92a59973/assets/img/egeria.png
 keywords:
   - odpi, egeria, cts

--- a/charts/egeria-cts/scripts/config-egeria.sh
+++ b/charts/egeria-cts/scripts/config-egeria.sh
@@ -30,6 +30,18 @@ curl -f -k -w "\n   (%{http_code} - %{url_effective})\n" --silent -X POST \
   "${EGERIA_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_SERVER}/conformance-suite-workbenches/repository-workbench/repositories" \
   --data '{"class":"RepositoryConformanceWorkbenchConfig","tutRepositoryServerName":"'"${TUT_SERVER}"'","maxSearchResults":'${CTS_FACTOR}' }' || exit $?
 
+# Custom audit log configuration to help troubleshooting errors and exceptions for CTS server #
+# Remove all audit log destinations (removes default) #
+curl -f -k -w "\n   (%{http_code} - %{url_effective})\n" --silent -X DELETE \
+  --header "Content-Type: application/json" \
+  "${EGERIA_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_SERVER}/audit-log-destinations" \
+  --data ''|| exit $?
+# Add the custom console destination using only Error and Exception severities #
+curl -f -k -w "\n   (%{http_code} - %{url_effective})\n" --silent -X POST \
+  --header "Content-Type: application/json" \
+  "${EGERIA_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_SERVER}/audit-log-destinations/console" \
+  --data '["Error","Exception"]'|| exit $?
+
 echo -e '\n > Configuring technology under test:\n'
 
 curl -f -k -w "\n   (%{http_code} - %{url_effective})\n" --silent -X POST \

--- a/charts/egeria-cts/scripts/config-egeria.sh
+++ b/charts/egeria-cts/scripts/config-egeria.sh
@@ -78,4 +78,16 @@ curl -f -k -w "\n   (%{http_code} - %{url_effective})\n" --silent -X POST \
 curl -f -k -w "\n   (%{http_code} - %{url_effective})\n" --silent -X POST \
   "${EGERIA_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${TUT_SERVER}/cohorts/${EGERIA_COHORT}" || exit $?
 
+# Custom audit log configuration to help troubleshooting errors and exceptions for TUT server #
+# Remove all audit log destinations (removes default) #
+curl -f -k -w "\n   (%{http_code} - %{url_effective})\n" --silent -X DELETE \
+  --header "Content-Type: application/json" \
+  "${EGERIA_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${TUT_SERVER}/audit-log-destinations" \
+  --data ''|| exit $?
+# Add the custom console destination using only Error and Exception severities #
+curl -f -k -w "\n   (%{http_code} - %{url_effective})\n" --silent -X POST \
+  --header "Content-Type: application/json" \
+  "${EGERIA_ENDPOINT}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${TUT_SERVER}/audit-log-destinations/console" \
+  --data '["Error","Exception"]'|| exit $?
+
 echo -e "\n-- End of configuration"


### PR DESCRIPTION
Reducing servers audit-log severity to Error and Exception.
This should help us troubleshoot the automated CTS run. 

Next we should change it back to default console and add additional file based audit-log destination that always outputs error/exception events only - however this needs additional work on the github action: copy the newly outputted files outside of the container into the pipeline as artifacts.